### PR TITLE
Refactor/move search dir

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # Sample environment variables for the monitoring script
 
-# Set the home directory for the node (default is your $HOME)
+# Set the home directory for the node (default is your $HOME/hl, e.g. /home/ubuntu/hl or /root/hl)
 NODE_HOME=
 
 # Set the binary location (default is $HOME/hl-visor)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ nano .env
 ```
 Make sure that you fill out all the relevant variables:
 ```bash
-# The path to your node’s home directory.
-NODE_HOME=/path/to/your/node/home
+# The path to your node’s directory.
+NODE_HOME=/path/to/your/hl
 # The path to your hl-visor binary.
 NODE_BINARY=/path/to/hl-visor
 # Set to true if this node is a validator; otherwise, false.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-        "fmt"
 	"os"
 	"strconv"
 
@@ -13,6 +12,7 @@ import (
 type Config struct {
         HomeDir          string
 	NodeHome         string
+        BinaryHome       string
 	NodeBinary       string
 	IsValidator      bool
 	ValidatorAddress string
@@ -30,11 +30,15 @@ func LoadConfig() Config {
         if nodeHome == "" {
             nodeHome = homeDir + "/hl"
         }
-	fmt.Println(nodeHome)
+
+        binaryHome := os.Getenv("BINARY_HOME")
+        if binaryHome == "" {
+            binaryHome = homeDir
+        }
 
 	nodeBinary := os.Getenv("NODE_BINARY")
 	if nodeBinary == "" {
-		nodeBinary = homeDir + "/hl-visor"
+		nodeBinary = binaryHome + "/hl-visor"
 	}
 
 	isValidatorEnv := os.Getenv("IS_VALIDATOR")
@@ -48,6 +52,7 @@ func LoadConfig() Config {
 	return Config{
                 HomeDir:          homeDir,
 		NodeHome:         nodeHome,
+		BinaryHome:       binaryHome,
 		NodeBinary:       nodeBinary,
 		IsValidator:      isValidator,
 		ValidatorAddress: validatorAddress,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,13 @@ func LoadConfig() Config {
 
 	nodeHome := os.Getenv("NODE_HOME")
 	if nodeHome == "" {
-		nodeHome = os.Getenv("HOME")
+		nodeHome = os.Getenv("HOME") + "/hl"
 	}
 
 	nodeBinary := os.Getenv("NODE_BINARY")
 	if nodeBinary == "" {
-		nodeBinary = nodeHome + "/hl-visor"
+                homeDir = os.Getenv("HOME")
+		nodeBinary = homeDir + "/hl-visor"
 	}
 
 	isValidatorEnv := os.Getenv("IS_VALIDATOR")
@@ -42,6 +43,7 @@ func LoadConfig() Config {
 	validatorAddress := os.Getenv("VALIDATOR_ADDRESS")
 
 	return Config{
+                HomeDir:          homeDir,
 		NodeHome:         nodeHome,
 		NodeBinary:       nodeBinary,
 		IsValidator:      isValidator,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 // Config holds configuration values
 type Config struct {
+        HomeDir          string
 	NodeHome         string
 	NodeBinary       string
 	IsValidator      bool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+        "fmt"
 	"os"
 	"strconv"
 
@@ -29,6 +30,7 @@ func LoadConfig() Config {
         if nodeHome == "" {
             nodeHome = homeDir + "/hl"
         }
+	fmt.Println(nodeHome)
 
 	nodeBinary := os.Getenv("NODE_BINARY")
 	if nodeBinary == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,14 +24,14 @@ func LoadConfig() Config {
 		logger.Warning("No .env file found, using default environment variables")
 	}
 
-	nodeHome := os.Getenv("NODE_HOME")
-	if nodeHome == "" {
-		nodeHome = os.Getenv("HOME") + "/hl"
-	}
+        homeDir := os.Getenv("HOME")
+        nodeHome := os.Getenv("NODE_HOME")
+        if nodeHome == "" {
+            nodeHome = homeDir + "/hl"
+        }
 
 	nodeBinary := os.Getenv("NODE_BINARY")
 	if nodeBinary == "" {
-                homeDir = os.Getenv("HOME")
 		nodeBinary = homeDir + "/hl-visor"
 	}
 

--- a/internal/monitors/block_monitor.go
+++ b/internal/monitors/block_monitor.go
@@ -17,7 +17,7 @@ import (
 // StartBlockMonitor starts monitoring block time logs
 func StartBlockMonitor(cfg config.Config) {
 	go func() {
-		blockTimeDir := filepath.Join(cfg.NodeHome, "hl/data/block_times")
+		blockTimeDir := filepath.Join(cfg.NodeHome, "data/block_times")
 		var latestFile string
 		var fileOffset int64 = 0
 		isFirstRun := true

--- a/internal/monitors/proposal_monitor.go
+++ b/internal/monitors/proposal_monitor.go
@@ -18,7 +18,7 @@ import (
 // StartProposalMonitor starts monitoring proposal logs
 func StartProposalMonitor(cfg config.Config) {
 	go func() {
-		logsDir := filepath.Join(cfg.NodeHome, "hl/data/replica_cmds")
+		logsDir := filepath.Join(cfg.NodeHome, "data/replica_cmds")
 		var latestFile string
 		var fileOffset int64 = 0
 		for {


### PR DESCRIPTION
Introduces and `NODE_BINARY` `NODE_HOME` to improve flexibility under non standard setups

- updates `.env.sample` and readme to reflect the new vars setup
- refactors `config.go` to handle `NODE_HOME` and `NODE_BINARY` extraction, ensuring the correct binary path is set based on user environment
- adjusts log directory paths in `block_monitor.go` and `proposal_monitor.go` to use `NODE_HOME`