### PR TITLE
Mainnet fixes, support disabling evm 

### DIFF
--- a/cmd/hl-exporter/main.go
+++ b/cmd/hl-exporter/main.go
@@ -32,6 +32,7 @@ func main() {
 		fmt.Println("  --alias            Node alias (required when OTLP is enabled)")
 		fmt.Println("  --chain            Chain type (required when OTLP is enabled: 'mainnet' or 'testnet')")
 		fmt.Println("  --otlp-insecure    Use insecure connection for OTLP (default: false)")
+		fmt.Println("  --evm              Enable EVM monitoring (default: true)")
 		os.Exit(1)
 	}
 
@@ -46,6 +47,7 @@ func main() {
 	alias := startCmd.String("alias", "", "Node alias (required when OTLP is enabled)")
 	chain := startCmd.String("chain", "", "Chain type (required when OTLP is enabled: 'mainnet' or 'testnet')")
 	otlpInsecure := startCmd.Bool("otlp-insecure", false, "Use insecure connection for OTLP (default: false)")
+	enableEVM := startCmd.Bool("evm", true, "Enable EVM monitoring (default: true)")
 
 	switch os.Args[1] {
 	case "start":
@@ -73,6 +75,7 @@ func main() {
 		NodeHome:   *nodeHome,
 		NodeBinary: *nodeBinary,
 		Chain:      *chain,
+		EnableEVM:  *enableEVM,
 	}
 
 	cfg := config.LoadConfig(flags)
@@ -105,6 +108,7 @@ func main() {
 		NodeHome:         cfg.NodeHome,
 		ValidatorAddress: validatorAddress,
 		IsValidator:      isValidator,
+		EnableEVM:        *enableEVM,
 	}
 
 	if err := metrics.InitMetrics(ctx, metricsConfig); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,14 @@ type Config struct {
 	BinaryHome string
 	NodeBinary string
 	Chain      string
+	EnableEVM  bool
 }
 
 type Flags struct {
 	NodeHome   string
 	NodeBinary string
 	Chain      string
+	EnableEVM  bool
 }
 
 // loads env vars and returns a Config struct
@@ -49,6 +51,7 @@ func LoadConfig(flags *Flags) Config {
 		NodeHome:   nodeHome,
 		NodeBinary: nodeBinary,
 		Chain:      flags.Chain,
+		EnableEVM:  flags.EnableEVM,
 	}
 
 	// override with flags if they're provided (non-empty)

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -39,11 +39,13 @@ func Start(ctx context.Context, cfg config.Config) {
 	logger.Info("Initializing update checker...")
 	go monitors.StartUpdateChecker(monitorCtx, cfg, updateErrCh)
 
-	logger.Info("Initializing evm monitor...")
-	go monitors.StartEVMBlockHeightMonitor(monitorCtx, cfg, evmErrCh) // Start the EVM Monitor
+	if cfg.EnableEVM {
+		logger.Info("Initializing evm monitor...")
+		go monitors.StartEVMBlockHeightMonitor(monitorCtx, cfg, evmErrCh) // Start the EVM Monitor
 
-	logger.Info("Initializing EVM Transactions monitor...")
-	go monitors.StartEVMTransactionsMonitor(monitorCtx, cfg, evmTxsErrCh)
+		logger.Info("Initializing EVM Transactions monitor...")
+		go monitors.StartEVMTransactionsMonitor(monitorCtx, cfg, evmTxsErrCh)
+	}
 
 	logger.Info("Initializing Validator Status monitor...")
 	monitors.StartValidatorStatusMonitor(ctx, cfg, validatorStatusErrCh)

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -37,7 +37,7 @@ func Start(ctx context.Context, cfg config.Config) {
 	go monitors.StartVersionMonitor(monitorCtx, cfg, versionErrCh)
 
 	logger.Info("Initializing update checker...")
-	go monitors.StartUpdateChecker(monitorCtx, updateErrCh)
+	go monitors.StartUpdateChecker(monitorCtx, cfg, updateErrCh)
 
 	logger.Info("Initializing evm monitor...")
 	go monitors.StartEVMBlockHeightMonitor(monitorCtx, cfg, evmErrCh) // Start the EVM Monitor
@@ -52,7 +52,7 @@ func Start(ctx context.Context, cfg config.Config) {
 	go monitors.StartValidatorIPMonitor(monitorCtx, cfg, validatorIPErrCh)
 
 	logger.Info("Initializing validator API monitor...")
-	go monitors.StartValidatorMonitor(monitorCtx, validatorErrCh)
+	go monitors.StartValidatorMonitor(monitorCtx, cfg, validatorErrCh)
 
 	logger.Info("Exporter is now running")
 

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -10,4 +10,5 @@ type MetricsConfig struct {
 	NodeHome         string
 	ValidatorAddress string
 	IsValidator      bool
+	EnableEVM        bool
 }

--- a/internal/monitors/update_checker.go
+++ b/internal/monitors/update_checker.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	binaryURL        = "https://binaries.hyperliquid.xyz/Testnet/hl-visor"
+	binaryURL        = "https://binaries.hyperliquid-testnet.xyz/Testnet/hl-visor"
 	localBinaryPath  = "/tmp/hl-visor-latest"
 	downloadInterval = 5 * time.Minute
 )


### PR DESCRIPTION
Gm gn

We've been using your great exporter since we went live on testnet, as we think it's the best developed.

Since we've been using it, we've made small changes to it. Opening this PR is our way of contributing.

We've added :
- Mainnet fixes: the --chain supports the "mainnet" value, but some values like API urls were hardcoded. It now checks the config to see what network we're monitoring on.
- Disabling evm : if you plan to be a validator (so don't want to support evm) and run with "non-validator" mode, the exporter will spam logs about not being able to monitor evm block height / txs. The --evm=<true | false> (default is true) now conditions the start of StartEVMBlockHeightMonitor and StartEVMTransactionsMonitor.

Please note that we're not Go developers. There are likely to be some errors regarding best practice or language understanding that we haven't understood.

Any feedback will be appreciated.