### PR TITLE
updated correct directory paths

### DIFF
--- a/internal/monitors/block_monitor.go
+++ b/internal/monitors/block_monitor.go
@@ -20,7 +20,7 @@ var lastBlockTime time.Time
 
 func StartBlockMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
 	go func() {
-		blockTimeDir := filepath.Join(cfg.NodeHome, "data/block_times")
+		blockTimeDir := filepath.Join(cfg.NodeHome, "data/node_fast_block_times")
 		var currentFile string
 		var fileReader *bufio.Reader
 		isFirstRun := true

--- a/internal/monitors/evm_block_height_monitor.go
+++ b/internal/monitors/evm_block_height_monitor.go
@@ -26,7 +26,7 @@ func StartEVMBlockHeightMonitor(ctx context.Context, cfg config.Config, errCh ch
 		return
 	}
 
-	evmBlockHeightDir := filepath.Join(cfg.NodeHome, "data/dhs/EthBlocks/hourly")
+	evmBlockHeightDir := filepath.Join(cfg.NodeHome, "data/dhs/EvmBlocks/hourly")
 	logger.Info("Starting EVM monitoring for validator node in directory: %s", evmBlockHeightDir)
 
 	go func() {

--- a/internal/monitors/evm_txs_monitor.go
+++ b/internal/monitors/evm_txs_monitor.go
@@ -26,7 +26,7 @@ func StartEVMTransactionsMonitor(ctx context.Context, cfg config.Config, errCh c
 		return
 	}
 
-	evmTxsDir := filepath.Join(cfg.NodeHome, "data/dhs/EthTxs/hourly")
+	evmTxsDir := filepath.Join(cfg.NodeHome, "data/dhs/EvmTxs/hourly")
 	logger.Info("Starting EVM transactions monitoring for validator node in directory: %s", evmTxsDir)
 
 	go func() {


### PR DESCRIPTION
This pull request updates directory paths in several monitoring functions to align with new naming conventions. The changes ensure consistency across the codebase for directory naming related to block times, EVM block heights, and EVM transactions.

### Directory Path Updates:

* [`internal/monitors/block_monitor.go`](diffhunk://#diff-389a603bac142784b6616c1e6687d608920c884ac633fe166d067f6b9ece6ad4L23-R23): Updated the `blockTimeDir` path to use `node_fast_block_times` instead of `block_times`.
* [`internal/monitors/evm_block_height_monitor.go`](diffhunk://#diff-ac64708facd42e2b86332d9924fe7120f0099a7c111415aee03d6b373f02c9d5L29-R29): Changed the `evmBlockHeightDir` path to use `EvmBlocks` instead of `EthBlocks`.
* [`internal/monitors/evm_txs_monitor.go`](diffhunk://#diff-8aeff16c4a6a96d499209811a277f0b0aec6ed5ed7f870eafc2301ee7a30e2c6L29-R29): Modified the `evmTxsDir` path to use `EvmTxs` instead of `EthTxs`.