### PR TITLE
Release hyperliquid-exporter v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,400 @@
 
 All notable changes to the Hyperliquid Exporter will be documented in this file.
 
+## Unreleased — internal branch
+
+Branched from upstream `main` at `ed02e16` (empty-block-dir SIGSEGV fix).
+Targets node operators first, validators and data extractors second.
+
+Verified live on a mainnet non-validator peer (24h/365d uptime, hl-node
+@ commit 5f658a6, 2026-05-25). Side-by-side scrape latency matches the
+production v2.0.0 build; zero error/warning lines in soak vs dozens
+per minute on prod.
+
+### Fixed
+
+- **`internal/metrics/prometheus.go`** — replaced the hand-rolled
+  timeout-via-goroutine in the `/metrics` handler with
+  `http.TimeoutHandler`. The previous version raced two writers on
+  the same `ResponseWriter`, producing the `superfluous
+  response.WriteHeader` warning every scrape that exceeded the budget.
+  Also adds `ReadHeaderTimeout` and a 5s server-shutdown deadline.
+- **`internal/monitors/evm_monitor.go`** — stop emitting WARNING per
+  block whose gas limit isn't exactly 2M or ≥30M. The intermediate
+  3M tier is common, so the existing categorisation produced
+  sustained log spam. Adds a "small" bucket; keeps "other" silent.
+- **`internal/exporter/runMonitor`** wraps every monitor goroutine in
+  `recover()`, logs the stack, and counts the panic. A bug in one
+  monitor no longer leaves the metric permanently frozen.
+- **`internal/monitors/safego.go`** — `goSafe` helper that does the
+  same for the *inner* goroutines that nearly every monitor launches
+  and returns from immediately (the outer wrapper alone wasn't enough
+  protection). All long-running inner goroutines across consensus,
+  evm, evm_account, proposal, validator_api, version, update_checker,
+  validator_ip, validator_latency, validator_status, replica, and
+  round_advance now run under panic recovery with their monitor name
+  attributed to `hl_exporter_monitor_panics_total`.
+- **`internal/monitors/consensus_monitor.go`** — `qcSignatures`,
+  `tcVotes`, and `validatorCache` were unbounded maps growing with
+  validator-set churn. Added last-seen tracking plus a 10-min
+  housekeeping ticker that drops entries unseen for an hour;
+  `validatorCache` is now an LRU.
+
+### Added — new monitors
+
+#### `visor` — node sync health
+Reads `$NODE_HOME/hyperliquid_data/visor_abci_state.json` (live
+snapshot) and falls back to `data/visor_abci_states/hourly/<date>/<hour>`
+when the snapshot is absent. Exposes:
+
+| metric | meaning |
+| --- | --- |
+| `hl_visor_height` | block height applied |
+| `hl_visor_initial_height` | start point for the current visor process |
+| `hl_visor_blocks_applied` | height − initial_height |
+| `hl_visor_consensus_ahead_of_wall_seconds` | consensus_time − wall_clock_time (positive = chain ahead of local wall) |
+| `hl_visor_reference_lag_seconds` | when the visor reports it |
+| `hl_visor_scheduled_freeze_height` | 0 if not scheduled |
+| `hl_visor_last_observation_age_seconds` | staleness of the exporter's sample, derived from the JSON's wall_clock_time |
+
+This is the single most useful "am I in sync" signal for an operator.
+
+#### `subsystem_latency` — per-subsystem latency profile
+Reads `$NODE_HOME/data/latency_summaries/<subsystem>/<YYYYMMDD>`. 15
+subsystems on the allowlist cover the block-production path and the
+Tokio async runtime. Exposes
+`hl_node_subsystem_latency_{mean,median,p90,p95,max,stddev}_seconds`,
+`hl_node_subsystem_work_fraction`, `hl_node_subsystem_samples_total`,
+each labelled by `subsystem`.
+
+Live values on a peer node: `node_fast_begin_block_to_commit` p95
+≈ 30 ms, `node_fast_block_duration` p95 ≈ 120 ms. Alert on sustained
+drift here for "node is falling behind".
+
+#### `crit_msg` — critical-message counters
+Reads `$NODE_HOME/data/crit_msg_stats/{hl-node,hl-visor}/<YYYYMMDD>`.
+Decoded against hl-node's `crit_msg.rs` schema (verified by binary
+inspection):
+
+| metric | meaning |
+| --- | --- |
+| `hl_node_bugs{source}` | cumulative `bug!` events (page-someone severity) |
+| `hl_node_crits{source}` | cumulative `crit!` events |
+| `hl_node_crit_locations{source}` | distinct (file, line) call sites that have fired a bug/crit |
+| `hl_node_critical_messages_base_time_seconds{source}` | when the current cycle began (process start) |
+
+mtime-based polling skips work when the file hasn't changed.
+
+#### `tcp_traffic` — per-peer throughput
+Reads `$NODE_HOME/data/tcp_traffic/hourly/<date>/<h>` every 30 s and
+publishes the top-16 peers per direction plus an `ip="other"` rollup.
+Per-IP cardinality stays bounded across peer churn because the monitor
+remembers which `{ip,direction}` series it set last tick and
+`Delete()`s any that drop out of the new top-N.
+
+| metric | meaning |
+| --- | --- |
+| `hl_p2p_peer_traffic{ip,direction}` | per-peer raw throughput (top-N + "other") |
+| `hl_p2p_total_traffic{direction}` | sum across all peers |
+| `hl_p2p_peer_count{direction}` | distinct peers seen in the latest sample |
+| `hl_p2p_sample_age_seconds` | age of the most recent sample read |
+
+Other monitors can call `monitors.LatestTCPTrafficSnapshot()` to read
+the same parsed sample without re-opening the file.
+
+#### `parent_peer` — primary upstream detection
+Inspired by dwellir-public's parent_peer_monitor. The inbound peer with
+the largest byte volume is the node's effective "parent" (upstream data
+source). Loss of the parent = node likely stops syncing. Consumes the
+shared `tcp_traffic` snapshot, so no extra IO.
+
+| metric | meaning |
+| --- | --- |
+| `hl_node_parent_peer_info{ip}` | 1 for the current parent peer (only one series active) |
+| `hl_node_parent_peer_traffic` | inbound throughput attributed to the parent |
+| `hl_node_parent_peer_tenure_seconds` | how long the current parent has held the role |
+| `hl_node_parent_peer_switches_total` | counter, +1 each time the parent changes |
+
+Logs a WARNING when the runner-up is within 10× of the top.
+
+Caveat noted on a live mainnet peer: bandwidth per peer oscillates
+wildly across 30s sampling windows, so the parent-of-last-sample can
+flap. A moving-window variant is a candidate refinement.
+
+#### `disk` — NODE_HOME consumption
+60s tick. Walks the NODE_HOME tree once a minute and statfs'es the
+host filesystem.
+
+| metric | meaning |
+| --- | --- |
+| `hl_node_disk_used_bytes` | sum of regular-file sizes under NODE_HOME |
+| `hl_node_disk_free_bytes` | statfs Bavail × Bsize |
+| `hl_node_disk_total_bytes` | statfs Blocks × Bsize |
+| `hl_node_disk_subdir_bytes{subdir}` | recursive size of hot subdirs |
+
+Real numbers from a live peer at scrape time: replica_cmds = 154 GB,
+periodic_abci_states = 44 GB, hyperliquid_data = 483 GB.
+
+#### `process` — hl-node / hl-visor resource usage
+Linux-only via `/proc`; build-tag-stubbed on other OSes. Looks up each
+configured process by exact `/proc/PID/comm` match, walks fd/, parses
+stat and status.
+
+| metric | meaning |
+| --- | --- |
+| `hl_node_process_up{process}` | 1 if alive in /proc on this tick, 0 otherwise |
+| `hl_node_process_start_time_seconds{process}` | derived from /proc btime + stat starttime |
+| `hl_node_process_cpu_seconds_total{process}` | utime+stime / CLK_TCK |
+| `hl_node_process_rss_bytes{process}` | VmRSS in bytes |
+| `hl_node_process_virt_bytes{process}` | VmSize in bytes |
+| `hl_node_process_threads{process}` | kernel-thread count |
+| `hl_node_process_open_fds{process}` | count of /proc/PID/fd entries |
+
+When the process disappears, gauges reset to 0 (rather than freeze)
+so `hl_node_process_up == 0` alerting fires reliably.
+
+#### `gossip_connections` — peer churn / capacity exhaustion
+Tails `$NODE_HOME/data/node_logs/gossip_connections/hourly/<date>/<h>`.
+Counts events by sanitized tag (verified_gossip_rpc,
+handle_stream_connection, performing_checks_on_stream, got_tcp_greeting,
+error_checking_connection, rejecting_gossip_stream_max_peers_reached,
+other). The capacity-reached and error-checking rates are the
+operator-actionable signals. Tracks file offset across ticks so
+restarts don't replay history as a counter spike.
+
+#### `snapshot_status` — periodic ABCI snapshot health (always on)
+Watches `$NODE_HOME/data/periodic_abci_state_statuses/<date>/<height>`.
+Each entry is an empty-file sentinel hl-node writes AFTER the
+corresponding `.rmp` snapshot completes; the sentinel outlives the
+`.rmp` itself, so this is the right source for "did the last
+snapshot succeed". Emits `hl_node_snapshot_last_height`,
+`hl_node_snapshot_last_age_seconds`, `hl_node_snapshot_known_count`.
+Alert on age > 15 min = pipeline stalled.
+
+#### `node_state` — freeze height + EVM checkpoint tier (always on)
+Three single-file reads from `$NODE_HOME/hyperliquid_data/`. Emits
+`hl_visor_freeze_abci_height`, `hl_visor_blocks_above_freeze`
+(derived from the visor monitor's current height via an atomic),
+`hl_evm_db_checkpoint_height{tier="fast"|"slow"}`, and
+`hl_evm_db_checkpoint_lag_blocks` (sustained > 0 = EVM slow tier
+falling behind).
+
+#### `info_probe` — active HTTP liveness probe (--probe-info-endpoint)
+First true liveness probe we have that doesn't depend on file
+mtimes. POSTs `{"type":"meta"}` to `http://127.0.0.1:3001/info`
+every 15s with a 5s timeout; counts 200 + non-empty body as up.
+Emits `hl_info_endpoint_up`, `hl_info_endpoint_latency_seconds`
+(histogram), `hl_info_endpoint_last_success_seconds`,
+`hl_info_endpoint_failures_total`. URL configurable via
+`--info-endpoint-url`. Off by default because some operators
+disallow outbound HTTP from the exporter, even to localhost.
+
+#### `tcp_lz4` — peer-level lz4 compression efficiency (--extended-metrics)
+Reads `$NODE_HOME/data/tcp_lz4_stats/<date>`. Per-peer top-N with
+"other" rollup + global aggregate. Compression ratio drifting
+toward 1.0 = either attack traffic or a node-side regression.
+Healthy steady state on a mainnet peer is ~0.62 (38% savings).
+
+#### `log_lines` — error/warn line counters (--extended-metrics)
+Counts `\n` in `$NODE_HOME/data/log/{infra,trade}/{error,warn}/<date>`.
+Both files empty on a healthy node; any non-zero value is
+operator-actionable. Modeled as a gauge so day-file rotation at
+UTC midnight cleanly resets the series.
+
+#### `public_ip` — IP drift + heartbeat (--extended-metrics)
+hl-node rewrites `last_known_public_ip.json` every ~13 minutes as
+a heartbeat. Emits `hl_node_public_ip_info{ip}`,
+`hl_node_public_ip_age_seconds`, `hl_node_public_ip_changes_total`.
+Alert on age > 30 min = heartbeat dead.
+
+#### `tokio_runtime` — per-task Tokio metrics (--extended-metrics)
+12-task allowlist bounds cardinality. Surfaces poll/idle/scheduled
+durations, slow polls, long delays, dropped tasks. Watch for
+slow-poll rates rising across MOST tasks (the
+`nv_stream_forward_client_blocks` task naturally has many slow
+polls — that's not the signal).
+
+#### `operator_config` — config-file mtime ages (--extended-metrics)
+mtime age of each file under `file_mod_time_tracker/`. Useful in
+postmortems: "was a config touched right before this incident".
+
+#### `tmp_dir` — orphaned tmp-file audit (--extended-metrics)
+Total bytes + count of files older than 24h under `$NODE_HOME/tmp`.
+The test peer carries ~2.5 GB of these from May/Jul 2025 crash
+remnants; the alert catches it without ssh'ing in.
+
+#### `tcp_connections` — kernel-truth peer connection count (always on)
+Linux-only. Parses `/proc/net/tcp{,6}` every 15s and counts
+connections per state on each hl-node listening port:
+`hl_p2p_tcp_connections{port,state}`. The ESTABLISHED count on 4001
+is the **true right-now peer count** (~6 on the test node) vs the
+~260-peer file-snapshot view. TIME_WAIT pile-ups (33 observed on
+4002) surface peer churn invisible from any other source. Cardinality
+bounded at 4 ports × ~11 states.
+
+#### `replica_runs` — filesystem-observable restart tracking (always on)
+Counts `data/replica_cmds/<run_timestamp>/` directories — one per
+hl-node startup — as `hl_node_observed_runs_total`. Emits the
+newest mtime as `hl_node_observed_run_start_seconds`. Deliberate
+redundancy with `/proc`-based process metrics: works in
+containerized deploys where `/proc` is hidden, and serves as a
+cross-check against `process_monitor`.
+
+#### `rocksdb` — LSM tree health (--extended-metrics)
+Tail-parses the last "DUMPING STATS" block from each RocksDB's LOG
+file (db_hub/Rpc, evm_db_hub_fast, evm_db_hub_slow). Skips
+db_hub/Evm and db_hub/Exchange because they are memtable-only on
+the current chain version. Exposes:
+
+| metric | meaning |
+| --- | --- |
+| `hl_rocksdb_sst_files{db}` | count of `.sst` files on disk |
+| `hl_rocksdb_write_stalls_total{db,reason}` | canonical LSM "falling behind" counters (l0-file-count-limit-stops, memtable-limit-stops, pending-compaction-bytes-stops, …) |
+| `hl_rocksdb_block_cache_usage_bytes{db}` | current LRU cache usage |
+
+`pending-compaction-bytes-stops` growing = writes blocked while the
+LSM catches up; the node will look sluggish before its disk does.
+
+#### `subsystem_steps` — per-step latency under bucket_guard + tcp_lz4 (--extended-metrics)
+The 19 bucket_guard sub-steps (begin_block, distribute_funding,
+update_funding_rates, …) and the 4 tcp_lz4 sub-steps
+(in_4001, out_4001, in_4002, out_4002) each carry their own latency
+profile under `latency_summaries/<subsystem>/<step>/<date>`. The
+existing subsystem_latency monitor only reads the parent subsystem;
+this one walks one level deeper.
+
+Captures tail-latency invisible from the rolled-up stats — e.g.
+`begin_block` p95 may sit at 7.5ms while max occasionally spikes to
+1.71s. Cardinality: 19×7 + 4×7 = 161 series.
+
+`hl_latency_bucket_guard_seconds{step,quantile}` and
+`hl_tcp_lz4_latency_seconds{direction,port,quantile}` with
+quantile ∈ {p50, p90, p95, max, mean, std_dev, work_frac}.
+
+#### `crit_locations` — per-source-location crit detail (--extended-metrics)
+Parses `/tmp/crit_msg_latest_stats/hl-node.json`, the rich form
+behind the on-disk crit_msg_stats tuple. Lets operators see WHICH
+source code site is firing, not just the rolled-up count.
+
+| metric | meaning |
+| --- | --- |
+| `hl_node_crit_location{file,line}` | crit count at that site |
+| `hl_node_crit_location_last_seen_seconds{file,line}` | last activation timestamp |
+
+`file` is the basename of the source path. Hard cap of 32 sites
+(sorted by count desc), enforced as a safety net even though the
+natural population is ~10.
+
+A real example from the live node: `tcp/read.rs:35` is firing with
+payload `tcp read bytes over limit @@ desc: "tcp greeting
+193.176.31.213 gossip"` — an attempted-flood signal that no other
+metric surfaces.
+
+#### `shell_exec_pending` (--extended-metrics, extends tmp_dir)
+`hl_node_shell_exec_pending` = file count under `$NODE_HOME/tmp/shell_rs_out/`.
+Each visor shell-exec drops a (usually empty) sentinel here; sustained
+growth means the visor's cleanup pass is broken. The test peer carries
+1257 of these from past crashes.
+
+#### Disk monitor — per-RocksDB rollups
+`hl_node_disk_subdir_bytes` now reports six per-RocksDB rollups
+under `hyperliquid_data/`: `db_hub/{Evm,Exchange,Rpc}`,
+`evm_db_hub_{fast,slow}`, and `evm_db_hub_slow/checkpoint`. Lets
+operators see which DB is bloating (the test peer's
+`evm_db_hub_slow/checkpoint` was 391 GB out of a 395 GB slow DB —
+99% of slow disk lives in one checkpoint dir).
+
+### Added — exporter self-observability
+
+- `/livez` — always 200 while the process is up
+- `/readyz` — 200 once every registered monitor goroutine has launched
+  (does NOT require real ticks, since some monitors legitimately no-op
+  on non-validator nodes)
+- `hl_exporter_build_info{version,commit,go_version}` — set via `-ldflags`
+- `hl_exporter_monitor_started_seconds{monitor}` — goroutine launch time
+- `hl_exporter_monitor_last_tick_seconds{monitor}` — last real
+  processing cycle; 0 if the monitor has not yet seen data. Use
+  `time() - hl_exporter_monitor_last_tick_seconds{monitor=...} > 600`
+  for stall alerts.
+- `hl_exporter_monitor_panics_total{monitor}` — recovered panics
+- `hl_exporter_monitor_errors_total{monitor}` — errors reported
+- `hl_exporter_ready` — mirrors `/readyz`
+
+A `hl_exporter version` subcommand prints the same build info to stdout.
+
+### Added — tests
+
+Upstream had zero Go tests. Baseline parser unit tests for the new
+monitors against real production data samples and the edge cases that
+broke in development:
+
+- `tcp_traffic_monitor_test.go` — `parseTCPTrafficLine`, `lastFullLine`
+  across torn-trailing-write / no-newline / only-newlines.
+- `crit_msg_monitor_test.go` — `parseCritMsgLine` + torn-last recovery
+  in `readLastCritMsg`.
+- `visor_monitor_test.go` — `latestHourlyFile` numeric hour sort
+  (regression for the "10" < "2" lex bug found on a live node);
+  `parseVisorTime` for each shape the visor emits.
+- `subsystem_latency_monitor_test.go` — `readLastSummary` against real
+  record + torn-last-line.
+- `gossip_connections_monitor_test.go` — `parseGossipConnectionLine`
+  tag mapping, "other" fallback, malformed inputs.
+
+`go test ./internal/monitors/` runs in under a second.
+
+### Added — flags
+
+| flag | purpose |
+| --- | --- |
+| `--metrics-port N` | listener port for `/metrics` (default 8086) |
+| `--skip-version-check` | skip the local `hl-node --version` probe (containers) |
+| `--skip-update-check` | skip the upstream binary download (containers) |
+| `--probe-info-endpoint` | enable active HTTP probe of `--serve-info` |
+| `--info-endpoint-url <url>` | override probe URL (default http://127.0.0.1:3001/info) |
+| `--extended-metrics` | enable the extended monitor set (tcp_lz4, log_lines, public_ip, tokio_runtime, operator_config, tmp_dir) |
+
+### Operator semantics — at-a-glance
+
+Critical alerts a node operator should set on this exporter:
+
+| symptom | metric expression |
+| --- | --- |
+| node crashed | `hl_node_process_up{process="hl-node"} == 0` for > 30s |
+| visor crashed | `hl_node_process_up{process="hl-visor"} == 0` for > 30s |
+| info endpoint down | `hl_info_endpoint_up == 0` for > 30s (requires `--probe-info-endpoint`) |
+| bug! emitted | `hl_node_bugs{source="hl-node"} > 0` |
+| crits accumulating | `rate(hl_node_crits[5m]) > 0` for > 5m |
+| disk filling | `hl_node_disk_free_bytes / hl_node_disk_total_bytes < 0.10` |
+| not in sync | `hl_visor_last_observation_age_seconds > 60` |
+| snapshot pipeline stalled | `hl_node_snapshot_last_age_seconds > 900` |
+| EVM tier divergence | `hl_evm_db_checkpoint_lag_blocks > 100` for > 10m |
+| max peers reached | `rate(hl_p2p_gossip_events_total{event_type="rejecting_gossip_stream_max_peers_reached"}[5m]) > 0` |
+| fast state begin-to-commit slow | `hl_node_subsystem_latency_p95_seconds{subsystem="node_fast_begin_block_to_commit"} > 0.1` for > 5m |
+| peer churn elevated | `rate(hl_p2p_gossip_events_total{event_type="error_checking_connection"}[5m]) > 0.1` |
+| public IP heartbeat dead | `hl_node_public_ip_age_seconds > 1800` (requires `--extended-metrics`) |
+| lz4 compression collapsed | `hl_p2p_lz4_global_ratio > 0.85` for > 10m (requires `--extended-metrics`) |
+| orphaned tmp files growing | `hl_node_tmp_stale_files > 100` (requires `--extended-metrics`) |
+| node logged something | `hl_node_log_lines{level="error"} > 0` (requires `--extended-metrics`) |
+| live peer count dropped | `hl_p2p_tcp_connections{port="4001",state="ESTABLISHED"} < 3` for > 5m |
+| peer churn on gossip-2 | `hl_p2p_tcp_connections{port="4002",state="TIME_WAIT"} > 50` |
+| RocksDB write-stalled | `rate(hl_rocksdb_write_stalls_total{reason=~"pending-compaction-bytes-stops|l0-file-count-limit-stops"}[5m]) > 0` (requires `--extended-metrics`) |
+| RocksDB cache exhausted | `hl_rocksdb_block_cache_usage_bytes / on() group_left() rocksdb_cache_capacity > 0.9` (capacity is a config constant — set as a recording rule) |
+| begin_block tail-latency | `hl_latency_bucket_guard_seconds{step="begin_block",quantile="max"} > 1` for > 5m (requires `--extended-metrics`) |
+| same crit hot-firing | `rate(hl_node_crit_location[5m]) > 0.5` (requires `--extended-metrics`) |
+| visor shell-cleanup broken | `hl_node_shell_exec_pending > 5000` (requires `--extended-metrics`) |
+| exporter monitor stuck | `time() - hl_exporter_monitor_last_tick_seconds > 600` (per monitor) |
+| exporter panicking | `rate(hl_exporter_monitor_panics_total[5m]) > 0` |
+
+### Deferred
+
+- Top-N per-peer TCP traffic moving-window stabilization (parent_peer flaps)
+- File-position persistence so monitors don't drop in-flight data on restart
+- TCP-probe peer latency (dwellir has it; lower priority than passive obs)
+- Outbound peer discovery beyond what tcp_traffic exposes
+- Per-step `latency_buckets` granularity (the 19 bucket_guard steps and
+  3 tcp_lz4 steps under `data/latency_buckets/` are not yet surfaced
+  individually — `subsystem_latency_monitor` covers the parent subsystems)
+
 ## [2.0.0] - 2025-08-03
 
 ### Added
@@ -75,4 +469,3 @@ All notable changes to the Hyperliquid Exporter will be documented in this file.
 - `--enable-prom` flag (Prometheus now always enabled)
 - `--disable-prom` flag (Prometheus now always enabled)
 - `hl_evm_transactions_total` metric (replaced by `hl_evm_tx_type_total`)
-

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ OPTIONS:
   --replica-metrics          # Transaction metrics (requires node --replica-cmds-style)
   --evm-metrics             # EVM chain metrics
   --contract-metrics        # Per-contract transaction tracking
+  --metrics-port N          # Prometheus port (default 8086)
+  --probe-info-endpoint     # Active HTTP probe of --serve-info
+  --extended-metrics        # Extra monitors (lz4, logs, RocksDB, etc.)
+  --skip-version-check      # For containerized deployments
+  --skip-update-check       # For containerized deployments
   --otlp                    # Enable OTLP export (requires --alias and --otlp-endpoint)
   --alias "validator-name"  # Node alias for OTLP
   --otlp-endpoint "url"     # OTLP endpoint URL
@@ -29,7 +34,7 @@ OPTIONS:
 Example: `./bin/hl_exporter start --chain mainnet --replica-metrics --evm-metrics`.
 
 By default, the exporter:
-- Exposes Prometheus metrics on `:8086/metrics`
+- Exposes Prometheus metrics on `:8086/metrics`, liveness on `/livez`, readiness on `/readyz`
 - Looks for log files in `$HOME/hl` and binaries in `$HOME/`
 - Uses `info` log level
 - Disables OTLP export
@@ -86,3 +91,5 @@ A Grafana dashboard is available at `grafana/dashboard.json`. Import it into you
 ## Documentation
 
 - [Metrics Reference](docs/metrics.md) - All metrics with descriptions and labels
+- [CHANGELOG](CHANGELOG.md)
+- [UPGRADING](UPGRADING.md) - v2 → v3 notes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,261 @@
+# UPGRADING — v2.0.0 to v3-internal
+
+Quick-reference for what changed, what stayed the same, and what to
+think about when rolling v3-internal into a place that's been running
+v2.0.0.
+
+## TL;DR
+
+- **Backward-compatible.** Every v2.0.0 metric still exists with the
+  same name, labels, and meaning. Existing dashboards and alert rules
+  work without modification.
+- **Default behavior unchanged.** Without any new flag, v3-internal
+  exposes the v2.0.0 metric set plus a small number of always-on
+  additions. It does NOT enable extended monitors, info probing, or
+  any new flag-gated behavior by default.
+- **64 new metric families** in the default-on set (v2 had 74, v3 has
+  ~138 with extended flags enabled).
+- **3 new CLI flags**, all optional. Existing systemd unit files
+  continue to work unchanged.
+- **No required upgrade order.** v3-internal can be deployed onto a
+  v2.0.0 host with no node-side coordination.
+
+## What didn't change
+
+All these continue to work exactly as in v2.0.0:
+
+- The default `:8086` listener (override with `--metrics-port`).
+- Every `hl_core_*`, `hl_consensus_*`, `hl_metal_*`, `hl_evm_*`,
+  `hl_software_*`, `hl_p2p_non_val_*`, `hl_go_*` metric. Names, labels,
+  semantics, all unchanged.
+- The OTLP export path (the v2 OTel instruments still feed it).
+- The existing flags: `--chain`, `--otlp`, `--otlp-endpoint`,
+  `--otlp-insecure`, `--alias`, `--node-home`, `--node-binary`,
+  `--evm-metrics`, `--contract-metrics`, `--contract-metrics-limit`,
+  `--replica-metrics`, `--validator-rtt`, `--log-level`.
+- The systemd-unit-friendly behavior (signal handling, graceful
+  shutdown).
+
+## What's new — always on
+
+These are added even without setting any new flag. They're cheap
+(file reads, no heavy parsing) and broadly useful:
+
+| family | meaning |
+| --- | --- |
+| `hl_visor_*` | sync-health from the visor JSON: height, blocks_applied, consensus_ahead_of_wall_seconds, reference_lag, freeze_height, blocks_above_freeze, last_observation_age_seconds |
+| `hl_node_snapshot_*` | periodic ABCI snapshot completion sentinels: last_height, last_age_seconds, known_count |
+| `hl_evm_db_checkpoint_*` | fast/slow EVM tier checkpoint heights + lag |
+| `hl_node_subsystem_latency_*` | per-subsystem latency (15-subsystem allowlist) — mean/median/p90/p95/max/stddev/work_frac |
+| `hl_node_bugs`, `hl_node_crits`, `hl_node_crit_locations` | crit_msg_stats decoded against hl-node's crit_msg.rs schema |
+| `hl_p2p_peer_traffic{ip,direction}` | top-16 peer throughput + "other" rollup |
+| `hl_p2p_total_traffic`, `hl_p2p_peer_count`, `hl_p2p_sample_age_seconds` | tcp_traffic aggregates |
+| `hl_node_parent_peer_*` | upstream parent-peer detection (info, traffic, tenure_seconds, switches_total) |
+| `hl_node_disk_*` | NODE_HOME byte size + statfs free/total + per-RocksDB subdir sizes |
+| `hl_node_process_*` | hl-node + hl-visor /proc resource use (up, cpu, rss, threads, fds, start_time, virt) |
+| `hl_p2p_gossip_events_total{event_type}` | gossip-connection events |
+| `hl_p2p_tcp_connections{port,state}` | kernel-truth peer connection state from /proc/net/tcp |
+| `hl_node_observed_runs_total`, `hl_node_observed_run_start_seconds` | filesystem-observable hl-node restart tracking |
+| `hl_visor_freeze_abci_height`, `hl_visor_blocks_above_freeze` | replay floor + height delta |
+| `hl_exporter_build_info`, `hl_exporter_monitor_*`, `hl_exporter_ready` | exporter self-observability |
+
+Plus the new endpoints: **`/livez`** (always 200 while running) and
+**`/readyz`** (200 once every registered monitor has launched).
+
+## What's new — opt-in via flags
+
+### `--probe-info-endpoint` (+ `--info-endpoint-url`)
+
+Adds an active HTTP probe of the node's `--serve-info` endpoint
+(POST `:3001/info` with `{"type":"meta"}`). This is the only true
+live-process probe; everything else reads files which can lie under
+clock skew or a write-stuck node.
+
+Exposes `hl_info_endpoint_up`, `hl_info_endpoint_latency_seconds`
+(histogram), `hl_info_endpoint_last_success_seconds`,
+`hl_info_endpoint_failures_total`. Off by default because some
+operators prohibit outbound HTTP from the exporter, even to localhost.
+
+### `--extended-metrics`
+
+Adds six additional monitors. None of them are expensive on their
+own; the flag groups them so a deep-dashboard operator can opt in
+without sprinkling per-feature flags:
+
+| family | source |
+| --- | --- |
+| `hl_p2p_lz4_*` | per-peer + global lz4 compression efficiency |
+| `hl_node_log_{lines,bytes}` | infra/trade error/warn day-files |
+| `hl_node_public_ip_*` | last_known_public_ip.json heartbeat + drift |
+| `hl_tokio_task_*` | 12-task Tokio runtime stats |
+| `hl_node_operator_config_age_seconds` | file_mod_time_tracker mtimes |
+| `hl_node_tmp_bytes`, `hl_node_tmp_stale_files`, `hl_node_shell_exec_pending` | `$NODE_HOME/tmp` audit |
+| `hl_rocksdb_sst_files`, `hl_rocksdb_write_stalls_total`, `hl_rocksdb_block_cache_usage_bytes` | parsed from each RocksDB's LOG file |
+| `hl_latency_bucket_guard_seconds`, `hl_tcp_lz4_latency_seconds` | per-step latency breakdowns under bucket_guard + tcp_lz4 |
+| `hl_node_crit_location{file,line}` + `hl_node_crit_location_last_seen_seconds` | per-source-line crit detail from `/tmp/crit_msg_latest_stats/hl-node.json` |
+
+### `--skip-version-check` and `--skip-update-check`
+
+For container deployments where the `hl-node` binary isn't reachable
+on the exporter's filesystem. Closes upstream issue #16. The
+existing `version_monitor` and `update_checker` would otherwise
+log errors every 30 minutes.
+
+### `--metrics-port`
+
+Default still 8086 (so no behavior change), but now configurable —
+useful when scrape ports conflict or when running side-by-side test
+deploys.
+
+## Subtle differences worth checking
+
+These will not break a v2 dashboard but the values may move slightly
+or new label values may appear:
+
+### EVM `block_type` label gained a `"small"` value
+
+`hl_evm_*{block_type}` in v2 emitted `"standard"` for ≤2M and
+`"high"` for ≥30M, with everything in between labeled `"other"` —
+plus a WARNING log line per `"other"` block. 3M-gas-limit blocks are
+now common, so v3-internal:
+
+- Adds a `"small"` block_type value (exactly 3M)
+- Keeps `"other"` silent for anything else in the middle
+- No longer logs a WARNING per intermediate block
+
+If any v2 alert filtered on `block_type="other"`, it will see less
+traffic. Recommended: change the filter to
+`block_type!~"standard|high"` to catch both `"small"` and `"other"`.
+
+### Scrape behavior under timeout
+
+The v2 `/metrics` handler raced two writers on the same
+`ResponseWriter` when a scrape exceeded its 30s timeout — produced
+`superfluous response.WriteHeader` log spam and could emit a
+half-written response with a trailing 503. v3 uses
+`http.TimeoutHandler` so timeouts return a clean 503 and never spam
+the log. If a v2 alert was set on the `superfluous response` log
+line, it will become silent — by design.
+
+### Flag-gated metrics still appear (at zero) when their flag is off
+
+The metrics added by `--probe-info-endpoint` and
+`--extended-metrics` are auto-registered at startup, so they show up
+on `/metrics` with their default zero value even when the relevant
+flag wasn't passed. Example: `hl_info_endpoint_up 0` is exposed by
+any v3 build, even without `--probe-info-endpoint` — it just never
+updates from zero because the probe never runs.
+
+This is normal Prometheus client-library behavior, not a bug, but
+it means an alert written as
+
+```
+hl_info_endpoint_up == 0   # fires on EVERY exporter without --probe-info-endpoint
+hl_p2p_lz4_global_ratio < 0.5   # fires on every exporter without --extended-metrics
+```
+
+…will produce permanent false positives on nodes where the flag
+isn't enabled.
+
+Two ways to guard:
+
+1. Pair the alert with a presence check that proves the monitor
+   actually ran:
+
+   ```
+   hl_info_endpoint_up == 0
+     and on() hl_exporter_monitor_last_tick_seconds{monitor="info_probe"} > 0
+   ```
+
+2. Or scope the alert by the build's commit/version (use
+   `hl_exporter_build_info`) so you only alert on the deployments
+   you expect to have the flag enabled.
+
+The same logic applies to every flag-gated family.
+
+### Bounded label cardinality
+
+v2's `consensus_monitor` accumulated three unbounded maps
+(`qcSignatures`, `tcVotes`, `validatorCache`) that grew with
+validator-set churn over months. v3 trims entries unseen for 1h on
+a 10-min housekeeping ticker, and `validatorCache` is now an LRU.
+The exposed metric set is the same; the underlying memory footprint
+is now bounded.
+
+## What if you only want the v2 surface?
+
+Just don't pass any new flag. The default-on additions don't break
+anything but they DO expose more series — if your Prometheus
+ingestion has tight per-target time-series limits, you may want to
+either:
+
+- Use a relabel-drop in the scrape config:
+
+  ```yaml
+  scrape_configs:
+    - job_name: hyperliquid
+      static_configs:
+        - targets: ['node:8086']
+      metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: 'hl_(visor|p2p_tcp_connections|node_(snapshot|process|disk|bugs|crits|crit_locations|observed_runs|observed_run_start|subsystem_|parent_peer)|evm_db_checkpoint_|exporter_)_.*'
+          action: drop
+  ```
+
+  …drops the v3 additions and keeps the v2 surface.
+
+- Or wait for a future build that supports `--legacy-v2-only`. Not
+  there today; raise it if you need it.
+
+## What if you want everything?
+
+```sh
+hl_exporter start \
+  --chain mainnet \
+  --replica-metrics --evm-metrics --contract-metrics \
+  --probe-info-endpoint \
+  --extended-metrics
+```
+
+…produces ~140 metric families on a non-validator peer. Scrape
+latency on our test node is identical to v2 (~10ms). CPU is ~5–10%
+higher than v2 due to the disk walks (subdir size tracking) and the
+tcp_traffic dedupe; if that's tight, drop `--extended-metrics`.
+
+## What if you're rolling onto an existing systemd unit?
+
+The default unit on the ValiDAO test node was:
+
+```ini
+ExecStart=/usr/local/bin/hl_exporter start \
+  --chain mainnet \
+  --replica-metrics --evm-metrics --contract-metrics
+```
+
+v3-internal accepts this exact line — no edit required. If you want
+the round-2-onward improvements, just add `--probe-info-endpoint
+--extended-metrics` to the same line and `systemctl daemon-reload`
++ `restart`.
+
+## Rollout sequence we recommend
+
+1. Drop the v3-internal binary in place. Don't change any flags
+   yet. Scrape works, all v2 dashboards continue to render, you
+   get the always-on additions for free.
+2. Add `--probe-info-endpoint`. Verify `hl_info_endpoint_up == 1`
+   on the dashboard.
+3. Add `--extended-metrics`. New families appear; existing ones
+   unchanged.
+4. Update alert rules to use the new operator-actionable signals
+   from the CHANGELOG's "Operator semantics" table.
+
+## What we INTENTIONALLY did NOT do
+
+- Did not change any v2.0.0 metric's name, labels, or semantics.
+- Did not change any existing flag default.
+- Did not introduce a required new flag.
+- Did not change the OTLP export schema.
+
+The v3-internal branch is a strict superset of v2.0.0 in terms of
+exposed metrics. If something looks like a regression, please flag
+it — it would be a bug.

--- a/cmd/hl-exporter/main.go
+++ b/cmd/hl-exporter/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -21,6 +22,7 @@ func main() {
 		fmt.Println("Usage: hl_exporter <command> [options]")
 		fmt.Println("Commands:")
 		fmt.Println("  start    Start the Hyperliquid exporter")
+		fmt.Println("  version  Print build information and exit")
 		fmt.Println("\nOptions:")
 		fmt.Println("  --log-level        Set the logging level (default: \"debug\")")
 		fmt.Println("  --enable-prom      Enable Prometheus endpoint (default: true)")
@@ -43,6 +45,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	if os.Args[1] == "version" || os.Args[1] == "--version" || os.Args[1] == "-v" {
+		fmt.Printf("hl_exporter %s (commit %s, %s)\n",
+			metrics.BuildVersion, metrics.BuildCommit, runtime.Version())
+		return
+	}
+
 	startCmd := flag.NewFlagSet("start", flag.ExitOnError)
 	logLevel := startCmd.String("log-level", "info", "Log level (debug, info, warning, error)")
 	enableOTLP := startCmd.Bool("otlp", false, "Enable OTLP export")
@@ -57,6 +65,12 @@ func main() {
 	contractLimit := startCmd.Int("contract-metrics-limit", 20, "Maximum number of individual contract labels to retain")
 	enableReplicaMetrics := startCmd.Bool("replica-metrics", false, "Enable replica commands transaction metrics")
 	enableValidatorRTT := startCmd.Bool("validator-rtt", false, "Enable validator RTT monitoring")
+	skipVersionCheck := startCmd.Bool("skip-version-check", false, "Skip the local hl-node --version probe (use when running in a container without the binary)")
+	skipUpdateCheck := startCmd.Bool("skip-update-check", false, "Skip the periodic upstream binary download for the up-to-date check")
+	metricsPort := startCmd.Int("metrics-port", 8086, "Port to expose Prometheus metrics on")
+	probeInfoEndpoint := startCmd.Bool("probe-info-endpoint", false, "Actively HTTP-probe the node's --serve-info endpoint as a liveness check")
+	infoEndpointURL := startCmd.String("info-endpoint-url", "", "URL the info probe POSTs to (default http://127.0.0.1:3001/info)")
+	enableExtendedMetrics := startCmd.Bool("extended-metrics", false, "Enable the extended monitor set (tcp_lz4, log lines, public IP, Tokio runtime, operator config, tmp dir)")
 
 	switch os.Args[1] {
 	case "start":
@@ -94,6 +108,11 @@ func main() {
 		ReplicaBufferSize:     8,  // Always use default 8MB
 		EVMBlockTypeMetrics:   *enableEVM, // Always enable block type metrics when EVM is enabled
 		EnableValidatorRTT:    enableValidatorRTT, // Use the bool pointer directly
+		SkipVersionCheck:      *skipVersionCheck,
+		SkipUpdateCheck:       *skipUpdateCheck,
+		ProbeInfoEndpoint:     *probeInfoEndpoint,
+		InfoEndpointURL:       *infoEndpointURL,
+		EnableExtendedMetrics: *enableExtendedMetrics,
 	}
 
 	cfg := config.LoadConfig(flags)
@@ -137,6 +156,7 @@ func main() {
 		ValidatorAddress: validatorAddress,
 		IsValidator:      isValidator,
 		EnableEVM:        *enableEVM,
+		PrometheusPort:   *metricsPort,
 	}
 
 	if err := metrics.InitMetrics(ctx, metricsConfig); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,28 @@ type Config struct {
 	MetricsAddr            string
 	LogLevel               string
 	LogFormat              string
+	// SkipVersionCheck disables the local hl-node --version probe. Set this
+	// when the exporter runs in a container that doesn't have the node
+	// binary on disk. Tracked in upstream issue #16.
+	SkipVersionCheck bool
+	// SkipUpdateCheck disables the periodic download of the latest hl-visor
+	// binary from binaries.hyperliquid.xyz. Useful for restricted
+	// environments and as a companion to SkipVersionCheck.
+	SkipUpdateCheck bool
+	// ProbeInfoEndpoint enables an active HTTP probe of the node's
+	// `--serve-info` endpoint as a liveness check. Off by default
+	// because some operators disallow outbound HTTP from the exporter
+	// process even to localhost.
+	ProbeInfoEndpoint bool
+	// InfoEndpointURL is the URL the info probe POSTs to; defaults to
+	// http://127.0.0.1:3001/info when empty.
+	InfoEndpointURL string
+	// EnableExtendedMetrics opts the exporter into the "extended" set
+	// of monitors: tcp_lz4, log line counters, public-IP heartbeat,
+	// Tokio task metrics, operator-config age, tmp-dir audit.
+	// Useful for deep operator dashboards; off by default to keep the
+	// scrape lean for the median user.
+	EnableExtendedMetrics bool
 }
 
 type Flags struct {
@@ -47,6 +69,11 @@ type Flags struct {
 	MetricsAddr           string
 	LogLevel              string
 	LogFormat             string
+	SkipVersionCheck      bool
+	SkipUpdateCheck       bool
+	ProbeInfoEndpoint     bool
+	InfoEndpointURL       string
+	EnableExtendedMetrics bool
 }
 
 // load env vars and returns a Config struct
@@ -97,6 +124,11 @@ func LoadConfig(flags *Flags) Config {
 		MetricsAddr:            flags.MetricsAddr,
 		LogLevel:               flags.LogLevel,
 		LogFormat:              flags.LogFormat,
+		SkipVersionCheck:       flags.SkipVersionCheck,
+		SkipUpdateCheck:        flags.SkipUpdateCheck,
+		ProbeInfoEndpoint:      flags.ProbeInfoEndpoint,
+		InfoEndpointURL:        flags.InfoEndpointURL,
+		EnableExtendedMetrics:  flags.EnableExtendedMetrics,
 	}
 
 	// override with flags if they're provided

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -23,45 +23,76 @@ func Start(ctx context.Context, cfg config.Config) {
 	validatorErrCh := make(chan error, 1)
 	versionErrCh := make(chan error, 1)
 	updateErrCh := make(chan error, 1)
-	evmErrCh := make(chan error)
-	evmTxsErrCh := make(chan error)
-	evmAccountErrCh := make(chan error)
-	validatorStatusErrCh := make(chan error)
+	evmErrCh := make(chan error, 1)
+	evmTxsErrCh := make(chan error, 1)
+	evmAccountErrCh := make(chan error, 1)
+	validatorStatusErrCh := make(chan error, 1)
 	validatorIPErrCh := make(chan error, 1)
 	coreTxErrCh := make(chan error, 1)
 	consensusErrCh := make(chan error, 1)
 	replicaErrCh := make(chan error, 1)
 	latencyErrCh := make(chan error, 1)
 	gossipErrCh := make(chan error, 1)
+	visorErrCh := make(chan error, 1)
+	subsystemLatencyErrCh := make(chan error, 1)
+	critMsgErrCh := make(chan error, 1)
+	tcpTrafficErrCh := make(chan error, 1)
+	parentPeerErrCh := make(chan error, 1)
+	diskErrCh := make(chan error, 1)
+	processErrCh := make(chan error, 1)
+	gossipConnectionsErrCh := make(chan error, 1)
+	snapshotStatusErrCh := make(chan error, 1)
+	nodeStateErrCh := make(chan error, 1)
+	infoProbeErrCh := make(chan error, 1)
+	tcpLz4ErrCh := make(chan error, 1)
+	logLinesErrCh := make(chan error, 1)
+	publicIPErrCh := make(chan error, 1)
+	tokioErrCh := make(chan error, 1)
+	operatorConfigErrCh := make(chan error, 1)
+	tmpDirErrCh := make(chan error, 1)
+	tcpConnectionsErrCh := make(chan error, 1)
+	replicaRunsErrCh := make(chan error, 1)
+	rocksDBErrCh := make(chan error, 1)
+	subsystemStepsErrCh := make(chan error, 1)
+	critLocationsErrCh := make(chan error, 1)
 
 	logger.InfoComponent("core", "Initializing block monitor...")
-	go monitors.StartBlockMonitor(monitorCtx, cfg, blockErrCh)
+	runMonitor("block", func() { monitors.StartBlockMonitor(monitorCtx, cfg, blockErrCh) })
 
 	// start val API monitor early to populate signer mappings
 	logger.InfoComponent("consensus", "Initializing validator API monitor...")
-	go monitors.StartValidatorMonitor(monitorCtx, cfg, validatorErrCh)
+	runMonitor("validator_api", func() { monitors.StartValidatorMonitor(monitorCtx, cfg, validatorErrCh) })
 
 	// only initialize proposal monitor if replica metrics are disabled
 	if !cfg.EnableReplicaMetrics {
 		logger.InfoComponent("consensus", "Initializing proposal monitor...")
-		go monitors.StartProposalMonitor(monitorCtx, cfg, proposalErrCh)
+		runMonitor("proposal", func() { monitors.StartProposalMonitor(monitorCtx, cfg, proposalErrCh) })
 	} else {
 		logger.InfoComponent("consensus", "Proposal monitor disabled - replica monitor will handle proposer counting")
 	}
 
-	logger.InfoComponent("system", "Initializing version monitor...")
-	go monitors.StartVersionMonitor(monitorCtx, cfg, versionErrCh)
+	if cfg.SkipVersionCheck {
+		logger.InfoComponent("system", "Version monitor disabled by --skip-version-check")
+	} else if _, err := monitors.NodeBinaryReady(cfg); err != nil {
+		logger.WarningComponent("system", "Skipping version monitor: %v (use --skip-version-check to silence)", err)
+	} else {
+		logger.InfoComponent("system", "Initializing version monitor...")
+		runMonitor("version", func() { monitors.StartVersionMonitor(monitorCtx, cfg, versionErrCh) })
+	}
 
-	logger.InfoComponent("system", "Initializing update checker...")
-	go monitors.StartUpdateChecker(monitorCtx, cfg, updateErrCh)
+	if cfg.SkipUpdateCheck {
+		logger.InfoComponent("system", "Update checker disabled by --skip-update-check")
+	} else {
+		logger.InfoComponent("system", "Initializing update checker...")
+		runMonitor("update_checker", func() { monitors.StartUpdateChecker(monitorCtx, cfg, updateErrCh) })
+	}
 
 	if cfg.EnableEVM {
-		// use EVM monitor that reads from evm_block_and_receipts
 		logger.InfoComponent("evm", "Initializing EVM monitor (using evm_block_and_receipts)...")
-		go monitors.StartEVMMonitor(monitorCtx, cfg, evmErrCh)
+		runMonitor("evm", func() { monitors.StartEVMMonitor(monitorCtx, cfg, evmErrCh) })
 
 		logger.InfoComponent("evm", "Initializing EVM Account monitor...")
-		go monitors.StartEVMAccountMonitor(monitorCtx, cfg, evmAccountErrCh)
+		runMonitor("evm_account", func() { monitors.StartEVMAccountMonitor(monitorCtx, cfg, evmAccountErrCh) })
 	}
 
 	logger.InfoComponent("consensus", "Initializing Validator Status monitor...")
@@ -69,74 +100,258 @@ func Start(ctx context.Context, cfg config.Config) {
 
 	if cfg.EnableValidatorRTT {
 		logger.InfoComponent("consensus", "Initializing validator IP monitor...")
-		go monitors.StartValidatorIPMonitor(monitorCtx, cfg, validatorIPErrCh)
+		runMonitor("validator_ip", func() { monitors.StartValidatorIPMonitor(monitorCtx, cfg, validatorIPErrCh) })
 	} else {
 		logger.InfoComponent("consensus", "Validator IP monitor disabled")
 	}
 
 	logger.InfoComponent("consensus", "Initializing comprehensive consensus monitor...")
-	go monitors.StartConsensusMonitor(monitorCtx, &cfg, consensusErrCh)
+	runMonitor("consensus", func() { monitors.StartConsensusMonitor(monitorCtx, &cfg, consensusErrCh) })
 
 	// start validator latency monitor (only runs on validator nodes)
 	logger.InfoComponent("latency", "Initializing validator latency monitor...")
-	go monitors.StartValidatorLatencyMonitor(monitorCtx, &cfg, latencyErrCh)
+	runMonitor("validator_latency", func() { monitors.StartValidatorLatencyMonitor(monitorCtx, &cfg, latencyErrCh) })
 
 	// start gossip monitor (only runs if gossip_rpc logs exist)
 	logger.InfoComponent("gossip", "Initializing gossip monitor...")
-	go monitors.StartGossipMonitor(monitorCtx, &cfg, gossipErrCh)
+	runMonitor("gossip", func() { monitors.StartGossipMonitor(monitorCtx, &cfg, gossipErrCh) })
+
+	// visor sync-state monitor (always on — applies to all node roles)
+	logger.InfoComponent("visor", "Initializing visor state monitor...")
+	runMonitor("visor", func() { monitors.StartVisorMonitor(monitorCtx, cfg, visorErrCh) })
+
+	// per-subsystem latency monitor (always on)
+	logger.InfoComponent("subsystem_latency", "Initializing subsystem latency monitor...")
+	runMonitor("subsystem_latency", func() { monitors.StartSubsystemLatencyMonitor(monitorCtx, cfg, subsystemLatencyErrCh) })
+
+	// crit_msg_stats monitor (always on — alerts on fatal node messages)
+	logger.InfoComponent("crit_msg", "Initializing critical-message monitor...")
+	runMonitor("crit_msg", func() { monitors.StartCritMsgMonitor(monitorCtx, cfg, critMsgErrCh) })
+
+	// tcp_traffic monitor (per-peer throughput, top-N bounded)
+	logger.InfoComponent("tcp_traffic", "Initializing tcp_traffic monitor...")
+	runMonitor("tcp_traffic", func() { monitors.StartTCPTrafficMonitor(monitorCtx, cfg, tcpTrafficErrCh) })
+
+	// parent peer detection — depends on the tcp_traffic monitor publishing
+	// its snapshot, so launched after it. No file IO of its own.
+	logger.InfoComponent("parent_peer", "Initializing parent peer monitor...")
+	runMonitor("parent_peer", func() { monitors.StartParentPeerMonitor(monitorCtx, cfg, parentPeerErrCh) })
+
+	// disk usage of NODE_HOME and its filesystem
+	logger.InfoComponent("disk", "Initializing disk usage monitor...")
+	runMonitor("disk", func() { monitors.StartDiskMonitor(monitorCtx, cfg, diskErrCh) })
+
+	// hl-node/hl-visor process resource usage (Linux /proc)
+	logger.InfoComponent("process", "Initializing process monitor...")
+	runMonitor("process", func() { monitors.StartProcessMonitor(monitorCtx, cfg, processErrCh) })
+
+	// gossip-connection event counter (peer churn, max-peers-reached, etc.)
+	logger.InfoComponent("gossip_connections", "Initializing gossip-connections monitor...")
+	runMonitor("gossip_connections", func() { monitors.StartGossipConnectionsMonitor(monitorCtx, cfg, gossipConnectionsErrCh) })
+
+	// Phase A — always-on essentials.
+	logger.InfoComponent("snapshot_status", "Initializing snapshot-status monitor...")
+	runMonitor("snapshot_status", func() { monitors.StartSnapshotStatusMonitor(monitorCtx, cfg, snapshotStatusErrCh) })
+
+	logger.InfoComponent("node_state", "Initializing node-state monitor...")
+	runMonitor("node_state", func() { monitors.StartNodeStateMonitor(monitorCtx, cfg, nodeStateErrCh) })
+
+	logger.InfoComponent("tcp_connections", "Initializing TCP-connections monitor...")
+	runMonitor("tcp_connections", func() { monitors.StartTCPConnectionsMonitor(monitorCtx, cfg, tcpConnectionsErrCh) })
+
+	logger.InfoComponent("replica_runs", "Initializing replica-runs monitor...")
+	runMonitor("replica_runs", func() { monitors.StartReplicaRunsMonitor(monitorCtx, cfg, replicaRunsErrCh) })
+
+	// Phase B — gated by --probe-info-endpoint.
+	if cfg.ProbeInfoEndpoint {
+		logger.InfoComponent("info_probe", "Initializing info-endpoint probe...")
+		runMonitor("info_probe", func() { monitors.StartInfoProbeMonitor(monitorCtx, cfg, infoProbeErrCh) })
+	} else {
+		logger.InfoComponent("info_probe", "Info-endpoint probe disabled (--probe-info-endpoint to enable)")
+	}
+
+	// Phase C — gated by --extended-metrics.
+	if cfg.EnableExtendedMetrics {
+		logger.InfoComponent("tcp_lz4", "Initializing tcp_lz4 monitor...")
+		runMonitor("tcp_lz4", func() { monitors.StartTCPLz4Monitor(monitorCtx, cfg, tcpLz4ErrCh) })
+
+		logger.InfoComponent("log_lines", "Initializing log-lines monitor...")
+		runMonitor("log_lines", func() { monitors.StartLogLinesMonitor(monitorCtx, cfg, logLinesErrCh) })
+
+		logger.InfoComponent("public_ip", "Initializing public-IP monitor...")
+		runMonitor("public_ip", func() { monitors.StartPublicIPMonitor(monitorCtx, cfg, publicIPErrCh) })
+
+		logger.InfoComponent("tokio_runtime", "Initializing Tokio runtime monitor...")
+		runMonitor("tokio_runtime", func() { monitors.StartTokioRuntimeMonitor(monitorCtx, cfg, tokioErrCh) })
+
+		logger.InfoComponent("operator_config", "Initializing operator-config monitor...")
+		runMonitor("operator_config", func() { monitors.StartOperatorConfigMonitor(monitorCtx, cfg, operatorConfigErrCh) })
+
+		logger.InfoComponent("tmp_dir", "Initializing tmp-dir monitor...")
+		runMonitor("tmp_dir", func() { monitors.StartTmpDirMonitor(monitorCtx, cfg, tmpDirErrCh) })
+
+		logger.InfoComponent("rocksdb", "Initializing RocksDB monitor...")
+		runMonitor("rocksdb", func() { monitors.StartRocksDBMonitor(monitorCtx, cfg, rocksDBErrCh) })
+
+		logger.InfoComponent("subsystem_steps", "Initializing per-step subsystem latency monitor...")
+		runMonitor("subsystem_steps", func() { monitors.StartSubsystemStepsMonitor(monitorCtx, cfg, subsystemStepsErrCh) })
+
+		logger.InfoComponent("crit_locations", "Initializing crit-locations monitor...")
+		runMonitor("crit_locations", func() { monitors.StartCritLocationsMonitor(monitorCtx, cfg, critLocationsErrCh) })
+	} else {
+		logger.InfoComponent("extended_metrics", "Extended metrics disabled (--extended-metrics to enable)")
+	}
 
 	if cfg.EnableReplicaMetrics {
 		logger.InfoComponent("replica", "Initializing replica commands monitor (streaming)...")
 		replicaMonitor := monitors.NewReplicaMonitor(cfg.ReplicaDataDir, cfg.ReplicaBufferSize)
-		go func() {
+		runMonitor("replica", func() {
 			if err := replicaMonitor.Start(monitorCtx); err != nil {
 				replicaErrCh <- err
 			}
-		}()
+		})
 	}
 
 	logger.InfoComponent("system", "Exporter is now running")
 
 	// start memory monitoring
-	go metrics.StartMemoryMonitoring(monitorCtx)
+	runMonitor("memory", func() { metrics.StartMemoryMonitoring(monitorCtx) })
 
 	// start metrics cleanup to prevent unbounded map growth
 	metrics.StartMetricsCleanup()
 	defer metrics.StopMetricsCleanup()
 
+	// publish exporter build_info once and refresh the per-monitor health
+	// snapshot every 10s. Background goroutine so the values stay current
+	// without blocking the main error loop.
+	metrics.SetBuildInfo()
+	go func() {
+		t := time.NewTicker(10 * time.Second)
+		defer t.Stop()
+		metrics.PublishMonitorHealthSnapshot()
+		for {
+			select {
+			case <-monitorCtx.Done():
+				return
+			case <-t.C:
+				metrics.PublishMonitorHealthSnapshot()
+			}
+		}
+	}()
+
 	for {
 		select {
 		case err := <-blockErrCh:
+			metrics.IncMonitorError("block")
 			logger.ErrorComponent("core", "Block monitor error: %v", err)
 		case err := <-proposalErrCh:
+			metrics.IncMonitorError("proposal")
 			logger.ErrorComponent("consensus", "Proposal monitor error: %v", err)
 		case err := <-validatorErrCh:
+			metrics.IncMonitorError("validator_api")
 			logger.ErrorComponent("consensus", "Validator monitor error: %v", err)
 		case err := <-versionErrCh:
+			metrics.IncMonitorError("version")
 			logger.ErrorComponent("system", "Version monitor error: %v", err)
 		case err := <-updateErrCh:
+			metrics.IncMonitorError("update_checker")
 			logger.ErrorComponent("system", "Update checker error: %v", err)
 		case err := <-evmErrCh:
+			metrics.IncMonitorError("evm")
 			logger.ErrorComponent("evm", "EVM Monitor error: %v", err)
 		case err := <-evmTxsErrCh:
 			// This channel is no longer used but kept for compatibility
 			logger.ErrorComponent("evm", "Legacy EVM Transactions Monitor error (should not happen): %v", err)
 		case err := <-evmAccountErrCh:
+			metrics.IncMonitorError("evm_account")
 			logger.ErrorComponent("evm", "EVM Account Monitor error: %v", err)
 		case err := <-validatorStatusErrCh:
+			metrics.IncMonitorError("validator_status")
 			logger.ErrorComponent("consensus", "Validator Status Monitor error: %v", err)
 		case err := <-validatorIPErrCh:
+			metrics.IncMonitorError("validator_ip")
 			logger.ErrorComponent("consensus", "Validator IP Monitor error: %v", err)
 		case err := <-coreTxErrCh:
+			metrics.IncMonitorError("core_tx")
 			logger.ErrorComponent("core", "Core TX Monitor error: %v", err)
 		case err := <-consensusErrCh:
+			metrics.IncMonitorError("consensus")
 			logger.ErrorComponent("consensus", "Consensus monitor error: %v", err)
 		case err := <-replicaErrCh:
+			metrics.IncMonitorError("replica")
 			logger.ErrorComponent("replica", "Replica monitor error: %v", err)
 		case err := <-latencyErrCh:
+			metrics.IncMonitorError("validator_latency")
 			logger.ErrorComponent("latency", "Validator latency monitor error: %v", err)
 		case err := <-gossipErrCh:
+			metrics.IncMonitorError("gossip")
 			logger.ErrorComponent("gossip", "Gossip monitor error: %v", err)
+		case err := <-visorErrCh:
+			metrics.IncMonitorError("visor")
+			logger.ErrorComponent("visor", "Visor monitor error: %v", err)
+		case err := <-subsystemLatencyErrCh:
+			metrics.IncMonitorError("subsystem_latency")
+			logger.ErrorComponent("subsystem_latency", "Subsystem latency monitor error: %v", err)
+		case err := <-critMsgErrCh:
+			metrics.IncMonitorError("crit_msg")
+			logger.ErrorComponent("crit_msg", "Critical message monitor error: %v", err)
+		case err := <-tcpTrafficErrCh:
+			metrics.IncMonitorError("tcp_traffic")
+			logger.ErrorComponent("tcp_traffic", "TCP traffic monitor error: %v", err)
+		case err := <-parentPeerErrCh:
+			metrics.IncMonitorError("parent_peer")
+			logger.ErrorComponent("parent_peer", "Parent peer monitor error: %v", err)
+		case err := <-diskErrCh:
+			metrics.IncMonitorError("disk")
+			logger.ErrorComponent("disk", "Disk monitor error: %v", err)
+		case err := <-processErrCh:
+			metrics.IncMonitorError("process")
+			logger.ErrorComponent("process", "Process monitor error: %v", err)
+		case err := <-gossipConnectionsErrCh:
+			metrics.IncMonitorError("gossip_connections")
+			logger.ErrorComponent("gossip_connections", "Gossip-connections monitor error: %v", err)
+		case err := <-snapshotStatusErrCh:
+			metrics.IncMonitorError("snapshot_status")
+			logger.ErrorComponent("snapshot_status", "Snapshot-status monitor error: %v", err)
+		case err := <-nodeStateErrCh:
+			metrics.IncMonitorError("node_state")
+			logger.ErrorComponent("node_state", "Node-state monitor error: %v", err)
+		case err := <-infoProbeErrCh:
+			metrics.IncMonitorError("info_probe")
+			logger.ErrorComponent("info_probe", "Info-endpoint probe error: %v", err)
+		case err := <-tcpLz4ErrCh:
+			metrics.IncMonitorError("tcp_lz4")
+			logger.ErrorComponent("tcp_lz4", "tcp_lz4 monitor error: %v", err)
+		case err := <-logLinesErrCh:
+			metrics.IncMonitorError("log_lines")
+			logger.ErrorComponent("log_lines", "log-lines monitor error: %v", err)
+		case err := <-publicIPErrCh:
+			metrics.IncMonitorError("public_ip")
+			logger.ErrorComponent("public_ip", "public-IP monitor error: %v", err)
+		case err := <-tokioErrCh:
+			metrics.IncMonitorError("tokio_runtime")
+			logger.ErrorComponent("tokio_runtime", "Tokio runtime monitor error: %v", err)
+		case err := <-operatorConfigErrCh:
+			metrics.IncMonitorError("operator_config")
+			logger.ErrorComponent("operator_config", "Operator-config monitor error: %v", err)
+		case err := <-tmpDirErrCh:
+			metrics.IncMonitorError("tmp_dir")
+			logger.ErrorComponent("tmp_dir", "tmp-dir monitor error: %v", err)
+		case err := <-tcpConnectionsErrCh:
+			metrics.IncMonitorError("tcp_connections")
+			logger.ErrorComponent("tcp_connections", "tcp-connections monitor error: %v", err)
+		case err := <-replicaRunsErrCh:
+			metrics.IncMonitorError("replica_runs")
+			logger.ErrorComponent("replica_runs", "replica-runs monitor error: %v", err)
+		case err := <-rocksDBErrCh:
+			metrics.IncMonitorError("rocksdb")
+			logger.ErrorComponent("rocksdb", "RocksDB monitor error: %v", err)
+		case err := <-subsystemStepsErrCh:
+			metrics.IncMonitorError("subsystem_steps")
+			logger.ErrorComponent("subsystem_steps", "subsystem-steps monitor error: %v", err)
+		case err := <-critLocationsErrCh:
+			metrics.IncMonitorError("crit_locations")
+			logger.ErrorComponent("crit_locations", "crit-locations monitor error: %v", err)
 		case <-ctx.Done():
 			logger.InfoComponent("system", "Shutting down monitors...")
 			return

--- a/internal/exporter/safego.go
+++ b/internal/exporter/safego.go
@@ -1,0 +1,29 @@
+package exporter
+
+import (
+	"runtime/debug"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// runMonitor launches fn in a goroutine with panic recovery and registers
+// the monitor name with the metrics health tracker. On panic, the recovery
+// logs the stack and increments the per-monitor panic counter.
+//
+// Monitors are expected to be long-running. A panic kills only that one
+// goroutine; the rest of the exporter keeps running. Monitors that need
+// auto-restart should manage that internally via their own loop.
+func runMonitor(name string, fn func()) {
+	metrics.RegisterMonitor(name)
+	go func() {
+		metrics.MarkMonitorStarted(name)
+		defer func() {
+			if r := recover(); r != nil {
+				metrics.IncMonitorPanic(name)
+				logger.ErrorComponent(name, "monitor PANIC recovered: %v\n%s", r, debug.Stack())
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -11,4 +11,7 @@ type MetricsConfig struct {
 	ValidatorAddress string
 	IsValidator      bool
 	EnableEVM        bool
+	// PrometheusPort overrides the default 8086 listener. Useful for
+	// side-by-side test runs and for sites with port conflicts.
+	PrometheusPort int
 }

--- a/internal/metrics/health.go
+++ b/internal/metrics/health.go
@@ -1,0 +1,133 @@
+package metrics
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Build-time injected version information. Set via -ldflags.
+var (
+	BuildVersion   = "dev"
+	BuildCommit    = "unknown"
+	BuildGoVersion = ""
+)
+
+// monitorState tracks the runtime state of one monitor.
+type monitorState struct {
+	startedUnix  int64 // atomic; set once when the monitor goroutine launches
+	lastTickUnix int64 // atomic; updated on every real processing cycle
+	panics       int64 // atomic
+	errors       int64 // atomic
+	registered   bool
+}
+
+var (
+	monitorsMu sync.RWMutex
+	monitors   = map[string]*monitorState{}
+)
+
+// RegisterMonitor declares that a monitor exists. Required so the readyz
+// endpoint knows the full set of monitors it is waiting on.
+func RegisterMonitor(name string) {
+	monitorsMu.Lock()
+	defer monitorsMu.Unlock()
+	if _, ok := monitors[name]; !ok {
+		monitors[name] = &monitorState{registered: true}
+	}
+}
+
+// MarkMonitorStarted records the goroutine-launch time for a monitor.
+// /readyz uses this — a monitor counts as ready as soon as its goroutine
+// is running, whether or not it has data to process yet. Operators
+// use last_tick_seconds to detect actual stalls.
+func MarkMonitorStarted(name string) {
+	state := getOrCreate(name)
+	atomic.StoreInt64(&state.startedUnix, time.Now().Unix())
+}
+
+// MarkMonitorTick records that the monitor produced a successful processing
+// cycle. The readyz endpoint flips to ready once every registered monitor has
+// reported at least one tick.
+func MarkMonitorTick(name string) {
+	state := getOrCreate(name)
+	atomic.StoreInt64(&state.lastTickUnix, time.Now().Unix())
+}
+
+// IncMonitorPanic increments the recovered-panic counter for a monitor.
+func IncMonitorPanic(name string) {
+	state := getOrCreate(name)
+	atomic.AddInt64(&state.panics, 1)
+}
+
+// IncMonitorError increments the soft-error counter for a monitor. Use this
+// for parse / IO failures that the monitor recovers from on the next loop.
+func IncMonitorError(name string) {
+	state := getOrCreate(name)
+	atomic.AddInt64(&state.errors, 1)
+}
+
+func getOrCreate(name string) *monitorState {
+	monitorsMu.RLock()
+	state, ok := monitors[name]
+	monitorsMu.RUnlock()
+	if ok {
+		return state
+	}
+	monitorsMu.Lock()
+	defer monitorsMu.Unlock()
+	if state, ok = monitors[name]; ok {
+		return state
+	}
+	state = &monitorState{}
+	monitors[name] = state
+	return state
+}
+
+// Ready reports whether every registered monitor's goroutine has started.
+// We deliberately do NOT require each one to have produced a real tick —
+// many monitors legitimately sit idle on non-validator nodes (no consensus
+// dir) or when a feature is disabled. Operators alert on stalled monitors
+// via time() - hl_exporter_monitor_last_tick_seconds, not /readyz.
+func Ready() bool {
+	monitorsMu.RLock()
+	defer monitorsMu.RUnlock()
+	if len(monitors) == 0 {
+		return false
+	}
+	for _, state := range monitors {
+		if !state.registered {
+			continue
+		}
+		if atomic.LoadInt64(&state.startedUnix) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// MonitorSnapshot returns a copy of the current health state. Callbacks use
+// this when emitting the observable gauges.
+type MonitorSnapshot struct {
+	Name         string
+	StartedUnix  int64
+	LastTickUnix int64
+	Panics       int64
+	Errors       int64
+}
+
+func snapshotMonitors() []MonitorSnapshot {
+	monitorsMu.RLock()
+	defer monitorsMu.RUnlock()
+	out := make([]MonitorSnapshot, 0, len(monitors))
+	for name, state := range monitors {
+		out = append(out, MonitorSnapshot{
+			Name:         name,
+			StartedUnix:  atomic.LoadInt64(&state.startedUnix),
+			LastTickUnix: atomic.LoadInt64(&state.lastTickUnix),
+			Panics:       atomic.LoadInt64(&state.panics),
+			Errors:       atomic.LoadInt64(&state.errors),
+		})
+	}
+	return out
+}

--- a/internal/metrics/init.go
+++ b/internal/metrics/init.go
@@ -32,7 +32,11 @@ func InitMetrics(ctx context.Context, cfg MetricsConfig) error {
 	}
 
 	if cfg.EnablePrometheus {
-		if err := StartPrometheusServer(ctx, 8086); err != nil {
+		port := cfg.PrometheusPort
+		if port == 0 {
+			port = 8086
+		}
+		if err := StartPrometheusServer(ctx, port); err != nil {
 			return fmt.Errorf("failed to start Prometheus server: %w", err)
 		}
 	}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -10,45 +10,47 @@ import (
 	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
 )
 
+const scrapeTimeout = 30 * time.Second
+
 func StartPrometheusServer(ctx context.Context, port int) error {
 	mux := http.NewServeMux()
 
-	// middleware to log metrics requests with timeout
-	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Debug("Metrics endpoint called from %s", r.RemoteAddr)
-
-		// create context with timeout to prevent indefinite hangs
-		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-		defer cancel()
-
-		// create channel to signal completion
-		done := make(chan struct{})
-
-		go func() {
-			promhttp.Handler().ServeHTTP(w, r.WithContext(ctx))
-			close(done)
-		}()
-
-		select {
-		case <-done:
-			logger.Debug("Metrics endpoint response completed")
-		case <-ctx.Done():
-			logger.Error("Metrics endpoint timed out after 30 seconds")
-			http.Error(w, "Metrics collection timed out", http.StatusServiceUnavailable)
-		}
-	})
-
+	// http.TimeoutHandler buffers the response and writes a 503 if the inner
+	// handler exceeds the deadline. Unlike a hand-rolled goroutine+select, it
+	// never races with the inner handler on the ResponseWriter — which was the
+	// source of the "superfluous response.WriteHeader" log spam.
+	metricsHandler := http.TimeoutHandler(
+		promhttp.Handler(),
+		scrapeTimeout,
+		"Metrics collection timed out\n",
+	)
 	mux.Handle("/metrics", metricsHandler)
 
-	// health check endpoint for debugging
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK\n"))
+		_, _ = w.Write([]byte("OK\n"))
+	})
+
+	// /livez always 200s while the process is running. /readyz reports ready
+	// once every monitor has reported at least one successful tick.
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if Ready() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ready\n"))
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("not ready\n"))
 	})
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: mux,
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {
@@ -60,7 +62,9 @@ func StartPrometheusServer(ctx context.Context, port int) error {
 
 	go func() {
 		<-ctx.Done()
-		if err := server.Shutdown(context.Background()); err != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
 			logger.Error("Error shutting down Prometheus server: %v", err)
 		}
 	}()

--- a/internal/metrics/prometheus_instruments.go
+++ b/internal/metrics/prometheus_instruments.go
@@ -1,0 +1,573 @@
+package metrics
+
+import (
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// prometheus_instruments.go declares Prometheus metric instruments using
+// the prometheus client_golang library directly. These complement the
+// OpenTelemetry instruments declared in instruments.go: both land in the
+// same default registry that the OTel→Prometheus bridge reads, so they
+// appear on the /metrics endpoint without extra wiring.
+//
+// Why two flavours: the OTel instruments existed in v2 and feed both the
+// /metrics endpoint and the optional OTLP exporter. New gauges and
+// counters added on top of v2 (visor, latency, crit_msg, tcp_traffic,
+// parent_peer, disk, process, gossip_connections, and the exporter's own
+// self-observability) use the simpler client_golang path because OTLP
+// export isn't required for those operator-facing metrics. If a future
+// instrument needs OTLP export too, move it to instruments.go.
+//
+// Naming follows the existing hl_<area>_<metric> convention.
+
+// Visor / sync-state metrics (from internal/monitors/visor_monitor.go).
+var (
+	HLVisorHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_height",
+		Help: "Latest height observed by the visor (block height the node has applied).",
+	})
+	HLVisorInitialHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_initial_height",
+		Help: "Height at which the current visor instance started (sync starting point).",
+	})
+	HLVisorBlocksApplied = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_blocks_applied",
+		Help: "Blocks the visor has applied since startup (height - initial_height).",
+	})
+	HLVisorScheduledFreezeHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_scheduled_freeze_height",
+		Help: "Height at which the visor is scheduled to freeze (0 if not scheduled).",
+	})
+	// Difference between the chain-consensus timestamp recorded for the
+	// latest applied block and the local wall-clock time at the moment
+	// the visor wrote the sample. Positive => chain's consensus clock is
+	// ahead of this node's wall clock (typical, since blocks are timestamped
+	// at decision time and observed after propagation). Negative =>
+	// this node's wall clock is ahead of the chain (NTP drift or stale
+	// data). Sustained large absolute values warrant investigation.
+	HLVisorConsensusAheadOfWallSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_consensus_ahead_of_wall_seconds",
+		Help: "consensus_time - wall_clock_time for the latest visor sample, in seconds (positive = chain ahead of local wall).",
+	})
+	HLVisorReferenceLagSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_reference_lag_seconds",
+		Help: "Reference-node lag reported by the visor when available, in seconds.",
+	})
+	HLVisorLastObservationAge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_last_observation_age_seconds",
+		Help: "Age of the most recent visor sample read by the exporter, in seconds.",
+	})
+)
+
+// Subsystem-latency metrics (from internal/monitors/subsystem_latency_monitor.go).
+var (
+	subsystemLabels = []string{"subsystem"}
+
+	HLNodeSubsystemLatencyMean = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_mean_seconds",
+		Help: "Mean per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemLatencyMedian = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_median_seconds",
+		Help: "Median per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemLatencyP90 = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_p90_seconds",
+		Help: "p90 per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemLatencyP95 = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_p95_seconds",
+		Help: "p95 per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemLatencyMax = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_max_seconds",
+		Help: "Max per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemLatencyStdDev = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_latency_stddev_seconds",
+		Help: "Std-dev of per-sample latency for an internal hl-node subsystem.",
+	}, subsystemLabels)
+	HLNodeSubsystemWorkFrac = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_work_fraction",
+		Help: "Fraction of wall-clock time the subsystem spent doing work in the sample.",
+	}, subsystemLabels)
+	HLNodeSubsystemSamplesTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_subsystem_samples_total",
+		Help: "Total number of samples behind the latest aggregated row (cumulative).",
+	}, subsystemLabels)
+)
+
+// Critical-message metrics from $NODE_HOME/data/crit_msg_stats. The on-disk
+// schema is a tuple [start_time, n_bugs, n_crits, n_locations]:
+//   - n_bugs:      cumulative count of "bug!" events (most severe; crash on
+//                  bug if configured)
+//   - n_crits:     cumulative count of "crit!" events (alert tier)
+//   - n_locations: number of distinct (file, line) call sites that have
+//                  fired a bug or crit at least once
+//
+// Modeled as gauges so a source-process restart cleanly resets the series
+// (the cumulative counters reset to 0 on restart) rather than looking like
+// a Prometheus counter regression.
+var (
+	HLNodeBugsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_bugs",
+		Help: "Cumulative count of bug! events since the source process started. Any non-zero value is page-someone severity.",
+	}, []string{"source"})
+	HLNodeCritsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_crits",
+		Help: "Cumulative count of crit! events since the source process started. Sustained growth = ongoing incident.",
+	}, []string{"source"})
+	HLNodeCritLocations = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_crit_locations",
+		Help: "Distinct source-code call sites (file:line) that have fired a bug or crit at least once for this process lifetime.",
+	}, []string{"source"})
+	HLNodeCriticalMessagesBaseTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_critical_messages_base_time_seconds",
+		Help: "Unix timestamp at which the current critical-message counters started accumulating (source process start).",
+	}, []string{"source"})
+)
+
+// TCP-traffic metrics (from internal/monitors/tcp_traffic_monitor.go).
+// Sourced from $NODE_HOME/data/tcp_traffic/hourly. The exporter only
+// publishes the top-N peers per direction plus an "other" bucket, so
+// label cardinality is bounded regardless of how many peers the node
+// connects to. The raw values are per-30s-interval throughputs whose
+// unit is not documented by hl-node; treat them as a comparative rate.
+var (
+	HLP2PPeerTraffic = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_peer_traffic",
+		Help: "Per-peer TCP throughput from the latest tcp_traffic sample (unit: raw hl-node value, ~per-30s-interval rate). Labels: ip, direction (in/out). The literal label value ip=\"other\" sums all peers below the top-N cutoff.",
+	}, []string{"ip", "direction"})
+
+	HLP2PTotalTraffic = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_total_traffic",
+		Help: "Sum of TCP throughput across all peers, per direction.",
+	}, []string{"direction"})
+
+	HLP2PPeerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_peer_count",
+		Help: "Number of distinct peers seen in the latest tcp_traffic sample, per direction.",
+	}, []string{"direction"})
+
+	HLP2PSampleAgeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_p2p_sample_age_seconds",
+		Help: "Age of the most recent tcp_traffic sample read by the exporter, in seconds.",
+	})
+)
+
+// Parent-peer metrics (from internal/monitors/parent_peer_monitor.go).
+// For a non-validator node, the "parent peer" is the inbound peer
+// delivering the most bytes — effectively the upstream source of block
+// data. Losing it = the node likely stops syncing. Inspired by
+// dwellir-public/hyperliquid-exporter.
+var (
+	HLNodeParentPeerInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_parent_peer_info",
+		Help: "1 for the IP currently identified as the node's parent peer. Only ever has one series active at a time.",
+	}, []string{"ip"})
+
+	HLNodeParentPeerTraffic = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_parent_peer_traffic",
+		Help: "Inbound throughput attributed to the current parent peer in the latest sample (same units as hl_p2p_peer_traffic).",
+	})
+
+	HLNodeParentPeerTenureSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_parent_peer_tenure_seconds",
+		Help: "Time the current parent peer has held the role since the exporter last observed a switch.",
+	})
+
+	HLNodeParentPeerSwitches = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "hl_node_parent_peer_switches_total",
+		Help: "Number of times the parent peer has changed since the exporter started.",
+	})
+)
+
+// hl-node / hl-visor process metrics (from internal/monitors/process_monitor.go).
+// All labelled by `process` ∈ {"hl-node","hl-visor"} so a single dashboard
+// shows both. Sourced from /proc on Linux; the monitor no-ops on other
+// OSes.
+var (
+	HLNodeProcessUp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_up",
+		Help: "1 if the named hl-node process was found in /proc on the latest tick, 0 otherwise.",
+	}, []string{"process"})
+	HLNodeProcessStartTimeSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_start_time_seconds",
+		Help: "Unix timestamp at which the process started (derived from /proc btime + stat starttime).",
+	}, []string{"process"})
+	HLNodeProcessCPUSecondsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_cpu_seconds_total",
+		Help: "Cumulative CPU time consumed by the process (user+kernel), in seconds.",
+	}, []string{"process"})
+	HLNodeProcessRSSBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_rss_bytes",
+		Help: "Resident set size of the process, in bytes (/proc/PID/status VmRSS).",
+	}, []string{"process"})
+	HLNodeProcessVirtBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_virt_bytes",
+		Help: "Virtual memory size of the process, in bytes (/proc/PID/status VmSize).",
+	}, []string{"process"})
+	HLNodeProcessThreads = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_threads",
+		Help: "Number of OS threads in the process (/proc/PID/status Threads).",
+	}, []string{"process"})
+	HLNodeProcessOpenFDs = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_process_open_fds",
+		Help: "Number of open file descriptors held by the process (count of /proc/PID/fd entries).",
+	}, []string{"process"})
+)
+
+// Gossip-connections metrics (from internal/monitors/gossip_connections_monitor.go).
+// Each event_type is one tagged-union variant the node emits to
+// node_logs/gossip_connections. The most operator-actionable are:
+//   - "rejecting gossip stream because max peers reached" (capacity!)
+//   - "error checking connection"                          (churn)
+var (
+	HLP2PGossipEventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "hl_p2p_gossip_events_total",
+		Help: "Cumulative count of gossip-connection events emitted by hl-node, by event type.",
+	}, []string{"event_type"})
+)
+
+// Disk-usage metrics (from internal/monitors/disk_monitor.go). NODE_HOME
+// can grow without bound; a full disk silently breaks the node.
+var (
+	HLNodeDiskUsedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_disk_used_bytes",
+		Help: "Total bytes consumed by the NODE_HOME tree (sum of regular file sizes).",
+	})
+	HLNodeDiskFreeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_disk_free_bytes",
+		Help: "Bytes available on the filesystem holding NODE_HOME (statfs Bavail*Bsize).",
+	})
+	HLNodeDiskTotalBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_disk_total_bytes",
+		Help: "Total bytes on the filesystem holding NODE_HOME (statfs Blocks*Bsize).",
+	})
+	HLNodeDiskSubdirBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_disk_subdir_bytes",
+		Help: "Bytes consumed by major NODE_HOME subdirectories (per a hard-coded allowlist that targets known hot paths).",
+	}, []string{"subdir"})
+)
+
+// Exporter self-observability (from internal/exporter and the monitor
+// health module).
+var (
+	HLExporterBuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_exporter_build_info",
+		Help: "Build information for the running exporter; always 1.",
+	}, []string{"version", "commit", "go_version"})
+
+	HLExporterMonitorStartedSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_exporter_monitor_started_seconds",
+		Help: "Unix timestamp at which each monitor's goroutine launched.",
+	}, []string{"monitor"})
+	HLExporterMonitorLastTickSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_exporter_monitor_last_tick_seconds",
+		Help: "Unix timestamp of the most recent successful processing cycle per monitor (0 if the monitor has not yet processed real data).",
+	}, []string{"monitor"})
+	HLExporterMonitorPanicsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_exporter_monitor_panics_total",
+		Help: "Total recovered panics for each monitor since exporter start.",
+	}, []string{"monitor"})
+	HLExporterMonitorErrorsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_exporter_monitor_errors_total",
+		Help: "Total reported errors for each monitor since exporter start.",
+	}, []string{"monitor"})
+	HLExporterReady = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_exporter_ready",
+		Help: "1 once every registered monitor has produced at least one tick.",
+	})
+)
+
+// SetBuildInfo records the build_info gauge with the values baked in at
+// link time. Call once during startup.
+func SetBuildInfo() {
+	HLExporterBuildInfo.WithLabelValues(BuildVersion, BuildCommit, goVersion()).Set(1)
+}
+
+func goVersion() string {
+	if BuildGoVersion != "" {
+		return BuildGoVersion
+	}
+	return runtime.Version()
+}
+
+// PublishMonitorHealthSnapshot copies the in-memory monitor health state
+// into the per-monitor gauges. Invoked periodically from a small goroutine
+// so the values stay fresh between scrapes.
+func PublishMonitorHealthSnapshot() {
+	for _, s := range snapshotMonitors() {
+		if s.StartedUnix > 0 {
+			HLExporterMonitorStartedSeconds.WithLabelValues(s.Name).Set(float64(s.StartedUnix))
+		}
+		if s.LastTickUnix > 0 {
+			HLExporterMonitorLastTickSeconds.WithLabelValues(s.Name).Set(float64(s.LastTickUnix))
+		}
+		HLExporterMonitorPanicsTotal.WithLabelValues(s.Name).Set(float64(s.Panics))
+		HLExporterMonitorErrorsTotal.WithLabelValues(s.Name).Set(float64(s.Errors))
+	}
+	if Ready() {
+		HLExporterReady.Set(1)
+	} else {
+		HLExporterReady.Set(0)
+	}
+}
+
+// =====================================================================
+// Phase-A always-on additions.
+// =====================================================================
+
+// Periodic-snapshot status (from internal/monitors/snapshot_status_monitor.go).
+// hl-node writes one empty file at data/periodic_abci_state_statuses/
+// <YYYYMMDD>/<height> *after* the corresponding .rmp snapshot completes;
+// the empty file is a "snapshot succeeded" sentinel that outlives the
+// .rmp itself.
+var (
+	HLNodeSnapshotLastHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_snapshot_last_height",
+		Help: "Highest block height at which a periodic ABCI snapshot completed successfully.",
+	})
+	HLNodeSnapshotLastAgeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_snapshot_last_age_seconds",
+		Help: "Seconds since the most recent successful periodic snapshot (now - mtime of newest status sentinel).",
+	})
+	HLNodeSnapshotKnown = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_snapshot_known_count",
+		Help: "Number of snapshot status sentinels retained on disk in the latest date directory.",
+	})
+)
+
+// Node-state single-file gauges (from node_state_monitor.go).
+var (
+	HLVisorFreezeAbciHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_freeze_abci_height",
+		Help: "Replay floor written by hl-visor to hyperliquid_data/freeze_abci_height at process start.",
+	})
+	HLVisorBlocksAboveFreeze = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_visor_blocks_above_freeze",
+		Help: "hl_visor_height - hl_visor_freeze_abci_height (blocks applied since the current visor instance started).",
+	})
+	HLEVMDBCheckpointHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_evm_db_checkpoint_height",
+		Help: "Latest checkpoint height the named EVM DB tier has flushed to disk.",
+	}, []string{"tier"}) // tier ∈ {"fast","slow"}
+	HLEVMDBCheckpointLagBlocks = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_evm_db_checkpoint_lag_blocks",
+		Help: "hl_evm_db_checkpoint_height{tier=\"fast\"} - {tier=\"slow\"} (positive = slow tier behind fast).",
+	})
+)
+
+// =====================================================================
+// Phase-B --probe-info-endpoint flag.
+// =====================================================================
+
+var (
+	HLInfoEndpointUp = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_info_endpoint_up",
+		Help: "1 if the last POST :3001/info returned HTTP 200 with a non-empty body, 0 otherwise.",
+	})
+	HLInfoEndpointLatencySeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "hl_info_endpoint_latency_seconds",
+		Help:    "Latency of the active POST :3001/info {\"type\":\"meta\"} probe.",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	})
+	HLInfoEndpointLastSuccessSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_info_endpoint_last_success_seconds",
+		Help: "Unix timestamp of the last successful info-endpoint probe.",
+	})
+	HLInfoEndpointFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "hl_info_endpoint_failures_total",
+		Help: "Cumulative count of failed info-endpoint probes since exporter start.",
+	})
+)
+
+// =====================================================================
+// Phase-C --extended-metrics flag.
+// =====================================================================
+
+// tcp_lz4 — peer-level + global lz4 compression stats from
+// data/tcp_lz4_stats/<YYYYMMDD>.
+var (
+	HLP2PLz4CompressionRatio = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_compression_ratio",
+		Help: "lz4 compression ratio (bytes-after / bytes-before) for a peer in the latest sample. 1.0 = uncompressible. The literal ip=\"other\" sums all peers below the top-N cutoff.",
+	}, []string{"ip", "direction"})
+	HLP2PLz4BytesTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_bytes_total",
+		Help: "Cumulative compressed bytes since the source process started, per peer/direction.",
+	}, []string{"ip", "direction"})
+	HLP2PLz4PacketsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_packets_total",
+		Help: "Cumulative compressed packets since the source process started, per peer/direction.",
+	}, []string{"ip", "direction"})
+	HLP2PLz4GlobalRatio = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_global_ratio",
+		Help: "lz4 compression ratio across all peers (global aggregate row).",
+	})
+	HLP2PLz4GlobalBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_global_bytes_total",
+		Help: "Cumulative compressed bytes across all peers since the source process started.",
+	})
+	HLP2PLz4GlobalPackets = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_p2p_lz4_global_packets_total",
+		Help: "Cumulative compressed packets across all peers since the source process started.",
+	})
+)
+
+// log_lines — line counts in data/log/{infra,trade}/{error,warn}/<YYYYMMDD>.
+var (
+	HLNodeLogLinesTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_log_lines",
+		Help: "Lines in the day's log file. Modeled as a gauge so the per-day file rotation cleanly resets the series at midnight.",
+	}, []string{"stream", "level"})
+	HLNodeLogBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_log_bytes",
+		Help: "Size in bytes of the day's log file.",
+	}, []string{"stream", "level"})
+)
+
+// public_ip — heartbeat + change detection on last_known_public_ip.json.
+var (
+	HLNodePublicIPInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_public_ip_info",
+		Help: "1 for the IP currently reported as the node's public address.",
+	}, []string{"ip"})
+	HLNodePublicIPAgeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_public_ip_age_seconds",
+		Help: "Age of last_known_public_ip.json (now - mtime); should refresh every ~13 min while hl-node runs.",
+	})
+	HLNodePublicIPChangesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "hl_node_public_ip_changes_total",
+		Help: "Cumulative count of public-IP changes observed since the exporter started.",
+	})
+)
+
+// tokio_runtime — per-task Tokio metrics from
+// data/tokio_spawn_forever_metrics/hourly/<date>/<hour>.
+var (
+	HLTokioTaskPollSecondsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_poll_seconds_total",
+		Help: "Cumulative poll time for the named Tokio task since the source process started.",
+	}, []string{"task"})
+	HLTokioTaskPollsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_polls_total",
+		Help: "Cumulative poll count for the named Tokio task.",
+	}, []string{"task"})
+	HLTokioTaskSlowPollsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_slow_polls_total",
+		Help: "Cumulative slow polls (poll exceeded the runtime's slow-poll threshold).",
+	}, []string{"task"})
+	HLTokioTaskLongDelaysTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_long_delays_total",
+		Help: "Cumulative long scheduling delays (task waited too long to be polled after becoming ready).",
+	}, []string{"task"})
+	HLTokioTaskIdleSecondsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_idle_seconds_total",
+		Help: "Cumulative idle time (task awaiting work) for the named Tokio task.",
+	}, []string{"task"})
+	HLTokioTaskDroppedTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tokio_task_dropped_total",
+		Help: "Cumulative dropped (panicked or cancelled) task count.",
+	}, []string{"task"})
+)
+
+// operator_config — mtime of file_mod_time_tracker/*.json files. Tells the
+// operator when they last changed local node config.
+var (
+	HLNodeOperatorConfigAgeSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_operator_config_age_seconds",
+		Help: "Age (now - mtime) of operator-edited config files under file_mod_time_tracker/.",
+	}, []string{"file"})
+)
+
+// tmp_dir — size + stale-file count under ~/hl/tmp.
+var (
+	HLNodeTmpBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_tmp_bytes",
+		Help: "Total size of files under $NODE_HOME/tmp. Persistent growth indicates orphaned writes from past crashes.",
+	})
+	HLNodeTmpStaleFiles = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_tmp_stale_files",
+		Help: "Number of files under $NODE_HOME/tmp older than 24h (orphaned write candidates).",
+	})
+)
+
+// =====================================================================
+// Phase-D round-5 additions.
+// =====================================================================
+
+// TCP connection state, parsed from /proc/net/tcp{,6}. Cardinality is
+// bounded: 4 listening ports × ~5 states.
+var (
+	HLP2PTCPConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_p2p_tcp_connections",
+		Help: "Count of TCP connections on each hl-node listening port, grouped by socket state. Sourced from /proc/net/tcp{,6}.",
+	}, []string{"port", "state"})
+)
+
+// Filesystem-observed restart tracking (always on).
+var (
+	HLNodeObservedRunsTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_observed_runs_total",
+		Help: "Number of hl-node runs observed via the filesystem (count of run-timestamp directories under data/replica_cmds/).",
+	})
+	HLNodeObservedRunStartSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_observed_run_start_seconds",
+		Help: "Unix timestamp of the most recent run's start, derived from the newest data/replica_cmds/<run_timestamp>/ mtime.",
+	})
+)
+
+// RocksDB LSM-tree stats (--extended-metrics).
+var (
+	HLRocksDBSSTFiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_rocksdb_sst_files",
+		Help: "Count of .sst files for the named RocksDB (LSM tree size). Sustained growth without compaction = stuck.",
+	}, []string{"db"})
+	HLRocksDBWriteStallsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_rocksdb_write_stalls_total",
+		Help: "Cumulative write-stall events from the RocksDB LOG file, by reason. Modeled as a gauge because the value resets on hl-node restart.",
+	}, []string{"db", "reason"})
+	HLRocksDBBlockCacheUsageBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_rocksdb_block_cache_usage_bytes",
+		Help: "Current block-cache usage in bytes, as reported by the RocksDB LOG's stats block.",
+	}, []string{"db"})
+)
+
+// Per-step latency for bucket_guard + tcp_lz4 subsystems (--extended-metrics).
+// Cardinality: 19 bucket_guard steps × 4 stats = 76, plus 4 tcp_lz4 steps × 4
+// stats = 16. Bounded by the on-disk subdirectory count.
+var (
+	HLLatencyBucketGuard = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_latency_bucket_guard_seconds",
+		Help: "Latency stats for individual bucket_guard sub-steps (e.g. begin_block, distribute_funding). quantile ∈ {p50,p90,p95,max,mean,std_dev,work_frac}.",
+	}, []string{"step", "quantile"})
+	HLTCPLz4Latency = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_tcp_lz4_latency_seconds",
+		Help: "Per-direction-per-port lz4 latency stats. quantile ∈ {p50,p90,p95,max,mean,std_dev,work_frac}.",
+	}, []string{"direction", "port", "quantile"})
+)
+
+// Per-location crit_msg detail (--extended-metrics). Hard cap on
+// cardinality at critLocationCap to defend against pathological growth.
+var (
+	HLNodeCritLocation = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_crit_location",
+		Help: "Per-source-location crit count from /tmp/crit_msg_latest_stats/hl-node.json. Value is the location's cumulative count since the source process started.",
+	}, []string{"file", "line"})
+	HLNodeCritLocationLastSeenSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hl_node_crit_location_last_seen_seconds",
+		Help: "Unix timestamp at which the named source location most recently emitted a crit.",
+	}, []string{"file", "line"})
+)
+
+// Shell-exec orphan tmp files (--extended-metrics, extends tmp_dir).
+var (
+	HLNodeShellExecPending = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "hl_node_shell_exec_pending",
+		Help: "Count of files under $NODE_HOME/tmp/shell_rs_out/. Each visor shell-exec leaves one; sustained growth indicates the visor's cleanup pass is broken.",
+	})
+)

--- a/internal/monitors/block_monitor.go
+++ b/internal/monitors/block_monitor.go
@@ -235,6 +235,7 @@ func parseBlockTimeLine(ctx context.Context, line string, stateType string) erro
 
 	// record apply duration with state type label
 	metrics.RecordApplyDurationWithLabel(applyDurationMs, stateType)
+	metrics.MarkMonitorTick("block")
 
 	logger.DebugComponent("core", "Updated %s state metrics: height=%.0f, apply_duration=%.6f, block_time=%s UTC, begin_block_wall_time=%s",
 		stateType, height, applyDuration, parsedTime.Format(time.RFC3339), beginBlockWallTime)

--- a/internal/monitors/consensus_monitor.go
+++ b/internal/monitors/consensus_monitor.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/validaoxyz/hyperliquid-exporter/internal/cache"
 	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
 	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
 	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
@@ -32,12 +33,28 @@ type heartbeatInfo struct {
 	timestamp time.Time
 }
 
+// Bounds on consensus-monitor maps. These are validator-keyed so the
+// practical population is at most the active validator set (~25), but
+// stale signers can accumulate across validator-set changes. A 1h
+// last-seen TTL is plenty for the QC participation logic, which only
+// cares about the recent sliding window.
+const (
+	consensusValidatorTTL = time.Hour
+	validatorCacheSize    = 1024
+	validatorCacheTTL     = 24 * time.Hour
+)
+
 // monitors consensus-related logs and metrics
 type ConsensusMonitor struct {
-	config         *config.Config
-	qcSignatures   map[string]int64  // Track QC signatures per signer
-	tcVotes        map[string]int64  // Track TC votes per signer
-	validatorCache map[string]string // Map signer address to validator address
+	config       *config.Config
+	mapsMu       sync.Mutex
+	qcSignatures map[string]int64     // Track QC signatures per signer
+	qcLastSeen   map[string]time.Time // last-seen timestamp per signer
+	tcVotes      map[string]int64     // Track TC votes per signer
+	tcLastSeen   map[string]time.Time
+	// validatorCache is a bounded, thread-safe LRU. Capacity covers the
+	// active set comfortably and stale entries expire on their own.
+	validatorCache *cache.LRUCache // signer -> validator address
 
 	// sliding window tracking for participation rates
 	qcWindow       []qcWindowEntry
@@ -77,13 +94,37 @@ func NewConsensusMonitor(cfg *config.Config) *ConsensusMonitor {
 	return &ConsensusMonitor{
 		config:          cfg,
 		qcSignatures:    make(map[string]int64),
+		qcLastSeen:      make(map[string]time.Time),
 		tcVotes:         make(map[string]int64),
-		validatorCache:  make(map[string]string),
+		tcLastSeen:      make(map[string]time.Time),
+		validatorCache:  cache.NewLRUCache(validatorCacheSize, validatorCacheTTL),
 		qcWindow:        make([]qcWindowEntry, 0),
 		windowSize:      100,       // keep last 100 blocks for participation calculation
 		windowDuration:  time.Hour, // or calculate based on last hour
 		disconnectedSet: make(map[string]bool),
 		heartbeats:      make(map[float64]heartbeatInfo),
+	}
+}
+
+// trimStaleValidators drops qcSignatures / tcVotes entries that haven't been
+// seen in consensusValidatorTTL. Called periodically by the monitor's
+// housekeeping loop so the maps don't grow without bound as the validator
+// set churns over time.
+func (m *ConsensusMonitor) trimStaleValidators() {
+	cutoff := time.Now().Add(-consensusValidatorTTL)
+	m.mapsMu.Lock()
+	defer m.mapsMu.Unlock()
+	for v, t := range m.qcLastSeen {
+		if t.Before(cutoff) {
+			delete(m.qcLastSeen, v)
+			delete(m.qcSignatures, v)
+		}
+	}
+	for v, t := range m.tcLastSeen {
+		if t.Before(cutoff) {
+			delete(m.tcLastSeen, v)
+			delete(m.tcVotes, v)
+		}
 	}
 }
 
@@ -142,10 +183,26 @@ func StartConsensusMonitor(ctx context.Context, cfg *config.Config, errCh chan<-
 	}
 
 	// start monitoring consensus logs
-	go m.monitorConsensusLogs(ctx, errCh)
+	goSafe("consensus", func() { m.monitorConsensusLogs(ctx, errCh) })
 
 	// start monitoring status logs
-	go m.monitorStatusLogs(ctx, errCh)
+	goSafe("consensus", func() { m.monitorStatusLogs(ctx, errCh) })
+
+	// periodic housekeeping: trim validator maps every 10 min. Drops entries
+	// that haven't been seen in consensusValidatorTTL.
+	goSafe("consensus", func() {
+		t := time.NewTicker(10 * time.Minute)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.trimStaleValidators()
+				m.validatorCache.CleanupExpired()
+			}
+		}
+	})
 }
 
 // monitors the consensus log files
@@ -439,8 +496,11 @@ func (m *ConsensusMonitor) processBlockRaw(blockData json.RawMessage) error {
 
 				formattedValidator := m.formatValidatorAddress(validator)
 
-				// track QC signatures
+				// track QC signatures (bounded by trimStaleValidators)
+				m.mapsMu.Lock()
 				m.qcSignatures[validator]++
+				m.qcLastSeen[validator] = time.Now()
+				m.mapsMu.Unlock()
 
 				metrics.IncrementQCSignatures(formattedValidator)
 			}
@@ -482,8 +542,11 @@ func (m *ConsensusMonitor) processBlockRaw(blockData json.RawMessage) error {
 					// just format it directly
 					formattedValidator := m.formatValidatorAddress(timeout.Validator)
 
-					// track TC votes
+					// track TC votes (bounded by trimStaleValidators)
+					m.mapsMu.Lock()
 					m.tcVotes[timeout.Validator]++
+					m.tcLastSeen[timeout.Validator] = time.Now()
+					m.mapsMu.Unlock()
 					metrics.IncrementTCParticipation(formattedValidator)
 				}
 			}
@@ -507,15 +570,16 @@ func (m *ConsensusMonitor) processBlockRaw(blockData json.RawMessage) error {
 
 // returns the validator address for a given signer
 func (m *ConsensusMonitor) getValidatorForSigner(signer string) string {
-	// first check cache
-	if validator, ok := m.validatorCache[signer]; ok {
-		return validator
+	if v, ok := m.validatorCache.Get(signer); ok {
+		if validator, ok2 := v.(string); ok2 {
+			return validator
+		}
 	}
 
 	// try to get from metrics package (which maintains a global mapping)
 	validator, exists := metrics.GetValidatorForSigner(signer)
 	if exists && validator != "" {
-		m.validatorCache[signer] = validator
+		m.validatorCache.Set(signer, validator)
 		return validator
 	}
 
@@ -660,7 +724,13 @@ func (m *ConsensusMonitor) updateQCParticipationRates() {
 	}
 
 	// set rate to 0 for validators who haven't participated
-	for validator := range m.qcSignatures {
+	m.mapsMu.Lock()
+	knownValidators := make([]string, 0, len(m.qcSignatures))
+	for v := range m.qcSignatures {
+		knownValidators = append(knownValidators, v)
+	}
+	m.mapsMu.Unlock()
+	for _, validator := range knownValidators {
 		if _, exists := participationCount[validator]; !exists {
 			formattedValidator := m.formatValidatorAddress(validator)
 			metrics.SetQCParticipationRate(formattedValidator, 0)

--- a/internal/monitors/crit_locations_monitor.go
+++ b/internal/monitors/crit_locations_monitor.go
@@ -1,0 +1,176 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// critLocationsPath is where hl-node writes the rich-form companion to
+// the on-disk crit_msg_stats counters. Format (single JSON document):
+//
+//	{
+//	  "start_time": "<iso>",
+//	  "n_bugs":     <int>,
+//	  "n_crits":    <int>,
+//	  "code_location_and_stats": [
+//	    [ {"fln": "<path>", "line": <int>},
+//	      {"n": <int>, "is_ignored": <bool>,
+//	       "first_seen": "<iso>", "last_seen": "<iso>",
+//	       "first_msg": "<string>"} ],
+//	    ...
+//	  ]
+//	}
+//
+// hl-visor.json is NOT produced by every node version — present on
+// the test peer's filesystem only as hl-node.json. The monitor skips
+// silently when the file doesn't exist.
+const critLocationsPath = "/tmp/crit_msg_latest_stats/hl-node.json"
+
+const critLocationsPollInterval = 60 * time.Second
+
+// critLocationCap is the hard cardinality ceiling on the metric. The
+// node naturally caps the array at ~10 elements on the test peer, but
+// a misbehaving node could in principle grow it without bound. Above
+// this cap we publish the top-N by count and drop the rest.
+const critLocationCap = 32
+
+// critLocationsMu protects activeLabels.
+var (
+	critLocationsMu sync.Mutex
+	// activeLabels remembers which (file,line) tuples were published last
+	// tick so we can Delete() any that fall out (mirrors the top-N
+	// discipline used by tcp_traffic_monitor).
+	activeLabels = map[[2]string]bool{}
+)
+
+// critMsgRichFile mirrors the on-disk schema.
+type critMsgRichFile struct {
+	StartTime string          `json:"start_time"`
+	NBugs     int64           `json:"n_bugs"`
+	NCrits    int64           `json:"n_crits"`
+	Stats     [][]json.RawMessage `json:"code_location_and_stats"`
+}
+
+type critLocation struct {
+	File       string `json:"fln"`
+	Line       int64  `json:"line"`
+	N          int64  `json:"n"`
+	IsIgnored  bool   `json:"is_ignored"`
+	FirstSeen  string `json:"first_seen"`
+	LastSeen   string `json:"last_seen"`
+	FirstMsg   string `json:"first_msg"`
+}
+
+// StartCritLocationsMonitor publishes per-source-location crit counts
+// and last-seen timestamps. Useful for distinguishing "we have one
+// recurring crit" from "a new crit type just appeared".
+//
+// The `file` label is the basename of the source path (not the full
+// `/home/ubuntu/hl/code_Mainnet/...` path) to keep series names
+// stable across hl-node releases that may relocate the source tree.
+func StartCritLocationsMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	if _, err := os.Stat(critLocationsPath); err != nil {
+		logger.InfoComponent("crit_locations",
+			"%s not present; monitor idle (this file is only written by some hl-node versions)", critLocationsPath)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("crit_locations", "watching %s", critLocationsPath)
+
+	ticker := time.NewTicker(critLocationsPollInterval)
+	defer ticker.Stop()
+
+	tickCritLocations()
+	metrics.MarkMonitorTick("crit_locations")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickCritLocations()
+			metrics.MarkMonitorTick("crit_locations")
+		}
+	}
+}
+
+func tickCritLocations() {
+	data, err := os.ReadFile(critLocationsPath)
+	if err != nil {
+		return
+	}
+	var rich critMsgRichFile
+	if err := json.Unmarshal(data, &rich); err != nil {
+		logger.DebugComponent("crit_locations", "parse: %v", err)
+		return
+	}
+
+	locs := make([]critLocation, 0, len(rich.Stats))
+	for _, pair := range rich.Stats {
+		if len(pair) < 2 {
+			continue
+		}
+		var key critLocation
+		if err := json.Unmarshal(pair[0], &key); err != nil {
+			continue
+		}
+		var detail critLocation
+		if err := json.Unmarshal(pair[1], &detail); err != nil {
+			continue
+		}
+		key.N = detail.N
+		key.IsIgnored = detail.IsIgnored
+		key.FirstSeen = detail.FirstSeen
+		key.LastSeen = detail.LastSeen
+		key.FirstMsg = detail.FirstMsg
+		locs = append(locs, key)
+	}
+
+	if len(locs) == 0 {
+		return
+	}
+
+	// Cap cardinality: keep the top-N by count.
+	if len(locs) > critLocationCap {
+		sort.Slice(locs, func(i, j int) bool { return locs[i].N > locs[j].N })
+		locs = locs[:critLocationCap]
+	}
+
+	current := map[[2]string]bool{}
+	for _, loc := range locs {
+		file := filepath.Base(loc.File)
+		line := fmt.Sprintf("%d", loc.Line)
+		labels := [2]string{file, line}
+		current[labels] = true
+
+		metrics.HLNodeCritLocation.WithLabelValues(file, line).Set(float64(loc.N))
+		if t, ok := parseVisorTime(loc.LastSeen); ok {
+			metrics.HLNodeCritLocationLastSeenSeconds.WithLabelValues(file, line).Set(float64(t.Unix()))
+		}
+	}
+
+	// Drop locations that dropped out of the current top-N.
+	critLocationsMu.Lock()
+	defer critLocationsMu.Unlock()
+	for lbl := range activeLabels {
+		if !current[lbl] {
+			metrics.HLNodeCritLocation.DeleteLabelValues(lbl[0], lbl[1])
+			metrics.HLNodeCritLocationLastSeenSeconds.DeleteLabelValues(lbl[0], lbl[1])
+			delete(activeLabels, lbl)
+		}
+	}
+	for lbl := range current {
+		activeLabels[lbl] = true
+	}
+}

--- a/internal/monitors/crit_locations_monitor_test.go
+++ b/internal/monitors/crit_locations_monitor_test.go
@@ -1,0 +1,70 @@
+package monitors
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Real /tmp/crit_msg_latest_stats/hl-node.json sample taken from a
+// live mainnet peer. Trimmed to two locations for brevity.
+const critLocationsSample = `{
+  "start_time": "2026-05-25T11:12:20.656667039",
+  "n_bugs": 0,
+  "n_crits": 24,
+  "code_location_and_stats": [
+    [
+      {"fln": "/home/ubuntu/hl/code_Mainnet/base/src/gossip_rpc_client.rs", "line": 59},
+      {"n": 7, "is_ignored": false, "first_seen": "2026-05-25T11:16:54.884388206", "last_seen": "2026-05-25T11:27:23.146756922", "first_msg": "...unexpected rpc response..."}
+    ],
+    [
+      {"fln": "/home/ubuntu/hl/code_Mainnet/base/src/nv_stream.rs", "line": 198},
+      {"n": 3, "is_ignored": false, "first_seen": "2026-05-25T11:17:00", "last_seen": "2026-05-25T11:28:00", "first_msg": "...reconnecting..."}
+    ]
+  ]
+}`
+
+func TestParseCritLocationsFile(t *testing.T) {
+	var rich critMsgRichFile
+	if err := json.Unmarshal([]byte(critLocationsSample), &rich); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if rich.NCrits != 24 {
+		t.Errorf("n_crits = %d, want 24", rich.NCrits)
+	}
+	if len(rich.Stats) != 2 {
+		t.Fatalf("got %d locations, want 2", len(rich.Stats))
+	}
+
+	// First location: key + detail.
+	var key critLocation
+	if err := json.Unmarshal(rich.Stats[0][0], &key); err != nil {
+		t.Fatalf("key parse: %v", err)
+	}
+	if key.File == "" {
+		t.Errorf("missing fln")
+	}
+	if key.Line != 59 {
+		t.Errorf("line = %d, want 59", key.Line)
+	}
+
+	var detail critLocation
+	if err := json.Unmarshal(rich.Stats[0][1], &detail); err != nil {
+		t.Fatalf("detail parse: %v", err)
+	}
+	if detail.N != 7 {
+		t.Errorf("n = %d, want 7", detail.N)
+	}
+	if detail.LastSeen == "" {
+		t.Errorf("missing last_seen")
+	}
+}
+
+func TestParseCritLocationsFile_Empty(t *testing.T) {
+	var rich critMsgRichFile
+	if err := json.Unmarshal([]byte(`{"start_time":"x","n_bugs":0,"n_crits":0,"code_location_and_stats":[]}`), &rich); err != nil {
+		t.Fatal(err)
+	}
+	if len(rich.Stats) != 0 {
+		t.Errorf("want 0 stats on empty doc, got %d", len(rich.Stats))
+	}
+}

--- a/internal/monitors/crit_msg_monitor.go
+++ b/internal/monitors/crit_msg_monitor.go
@@ -1,0 +1,167 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// critMsgSources lists the subdirectories under crit_msg_stats/ that we
+// publish. Both come standard with hl-node and hl-visor.
+var critMsgSources = []string{"hl-node", "hl-visor"}
+
+// crit_msg_stats files are appended every ~5 minutes by the node. We poll
+// at 30s so the latest record never sits more than half a sample interval
+// stale, but skip work when nothing has changed using the file's mtime.
+const critMsgPollInterval = 30 * time.Second
+
+// StartCritMsgMonitor watches $NODE_HOME/data/crit_msg_stats/<source>/<YYYYMMDD>.
+// File contents are JSON-line records of the form
+//
+//	[<sample_iso>, [<base_iso>, n_bugs, n_crits, n_locations]]
+//
+// where the three integer counts come from hl-node's crit_msg.rs:
+//
+//   - n_bugs      — cumulative count of bug! events
+//   - n_crits     — cumulative count of crit! events
+//   - n_locations — distinct (file, line) call sites that have fired a
+//                   bug or crit at least once since the process started
+//
+// All counts reset to 0 on process restart, so we model them as gauges,
+// which lets a restart cleanly zero the series instead of producing a
+// counter regression.
+//
+// Operator semantics:
+//   - n_bugs > 0 is the strongest "page someone" signal hl-node emits.
+//   - rate(n_crits) > 0 over a few minutes = ongoing incident.
+//   - n_locations growing means a NEW crit started firing (vs the same
+//     recurring one), which is useful for routing the alert.
+func StartCritMsgMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "crit_msg_stats")
+
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("crit_msg",
+			"crit_msg_stats directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("crit_msg", "watching %s", root)
+
+	lastMtime := make(map[string]time.Time)
+
+	ticker := time.NewTicker(critMsgPollInterval)
+	defer ticker.Stop()
+
+	tickCritMsg(root, lastMtime)
+	metrics.MarkMonitorTick("crit_msg")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickCritMsg(root, lastMtime)
+			metrics.MarkMonitorTick("crit_msg")
+		}
+	}
+}
+
+func tickCritMsg(root string, lastMtime map[string]time.Time) {
+	for _, source := range critMsgSources {
+		dir := filepath.Join(root, source)
+		datePath, err := latestDateFile(dir)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(datePath)
+		if err != nil {
+			continue
+		}
+		if prev, ok := lastMtime[source]; ok && info.ModTime().Equal(prev) {
+			continue // unchanged since last tick; the published gauges are still current
+		}
+		baseTime, nBugs, nCrits, nLocs, ok := readLastCritMsg(datePath)
+		if !ok {
+			continue
+		}
+		publishCritMsg(source, baseTime, nBugs, nCrits, nLocs)
+		lastMtime[source] = info.ModTime()
+	}
+}
+
+// readLastCritMsg returns the most recent record's base_time and the three
+// cumulative counts. Reads the whole file (these stay under a few KB per
+// day) and scans backwards for the first complete line.
+func readLastCritMsg(path string) (time.Time, int64, int64, int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, 0, 0, 0, false
+	}
+	for end := len(data); end > 0; {
+		// Skip trailing newlines so a torn write doesn't park us on an empty
+		// last "line".
+		for end > 0 && data[end-1] == '\n' {
+			end--
+		}
+		if end == 0 {
+			break
+		}
+		start := bytes.LastIndexByte(data[:end], '\n') + 1
+		line := bytes.TrimSpace(data[start:end])
+		if bt, b, c, l, ok := parseCritMsgLine(line); ok {
+			return bt, b, c, l, true
+		}
+		// Move to the previous line and try again (resilient to a torn last
+		// write).
+		end = start - 1
+	}
+	return time.Time{}, 0, 0, 0, false
+}
+
+func parseCritMsgLine(line []byte) (time.Time, int64, int64, int64, bool) {
+	if len(line) == 0 || line[0] != '[' {
+		return time.Time{}, 0, 0, 0, false
+	}
+	// Expected: [<sample_ts>, [<base_ts>, n_bugs, n_crits, n_locations]]
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return time.Time{}, 0, 0, 0, false
+	}
+	var inner []json.RawMessage
+	if err := json.Unmarshal(outer[1], &inner); err != nil || len(inner) < 4 {
+		return time.Time{}, 0, 0, 0, false
+	}
+	var baseStr string
+	if err := json.Unmarshal(inner[0], &baseStr); err != nil {
+		return time.Time{}, 0, 0, 0, false
+	}
+	baseTime, _ := parseVisorTime(baseStr)
+
+	nBugs, errB := strconv.ParseInt(string(inner[1]), 10, 64)
+	nCrits, errC := strconv.ParseInt(string(inner[2]), 10, 64)
+	nLocs, errL := strconv.ParseInt(string(inner[3]), 10, 64)
+	if errB != nil || errC != nil || errL != nil {
+		return time.Time{}, 0, 0, 0, false
+	}
+	return baseTime, nBugs, nCrits, nLocs, true
+}
+
+func publishCritMsg(source string, baseTime time.Time, nBugs, nCrits, nLocs int64) {
+	metrics.HLNodeBugsTotal.WithLabelValues(source).Set(float64(nBugs))
+	metrics.HLNodeCritsTotal.WithLabelValues(source).Set(float64(nCrits))
+	metrics.HLNodeCritLocations.WithLabelValues(source).Set(float64(nLocs))
+	if !baseTime.IsZero() {
+		metrics.HLNodeCriticalMessagesBaseTime.
+			WithLabelValues(source).
+			Set(float64(baseTime.Unix()))
+	}
+}

--- a/internal/monitors/crit_msg_monitor_test.go
+++ b/internal/monitors/crit_msg_monitor_test.go
@@ -1,0 +1,73 @@
+package monitors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCritMsgLine_RealSample(t *testing.T) {
+	// Real sample from a live mainnet peer's hl-node crit_msg file.
+	line := []byte(`["2026-05-25T09:54:58.011179114",["2026-05-23T08:24:54.982100058",0,113,4]]`)
+	bt, bugs, crits, locs, ok := parseCritMsgLine(line)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if bt.IsZero() {
+		t.Errorf("expected base_time parsed, got zero")
+	}
+	if bugs != 0 || crits != 113 || locs != 4 {
+		t.Errorf("got bugs=%d crits=%d locs=%d, want 0/113/4", bugs, crits, locs)
+	}
+}
+
+func TestParseCritMsgLine_AllZeros(t *testing.T) {
+	line := []byte(`["2026-05-25T09:30:14.690140970",["2026-05-22T08:00:10.495062428",0,0,0]]`)
+	bt, b, c, l, ok := parseCritMsgLine(line)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if b != 0 || c != 0 || l != 0 {
+		t.Errorf("expected all zeros, got %d/%d/%d", b, c, l)
+	}
+	if bt.IsZero() {
+		t.Errorf("expected base_time parsed")
+	}
+}
+
+func TestParseCritMsgLine_Malformed(t *testing.T) {
+	for _, line := range [][]byte{
+		[]byte(""),
+		[]byte("not json"),
+		[]byte("{}"),
+		[]byte(`["ts"]`),                   // missing inner
+		[]byte(`["ts",[]]`),                // empty inner
+		[]byte(`["ts",["base",1]]`),        // inner too short
+		[]byte(`["ts",["base","a","b","c"]]`), // non-integer counts
+	} {
+		_, _, _, _, ok := parseCritMsgLine(line)
+		if ok {
+			t.Errorf("expected fail on %q", line)
+		}
+	}
+}
+
+func TestReadLastCritMsg_TornTrailingWrite(t *testing.T) {
+	// Simulate a file with a complete line followed by a partial (torn)
+	// line — the partial JSON would unmarshal-fail, and the reader should
+	// walk backwards and return the complete preceding line.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260525")
+	contents := `["2026-05-25T09:34:57.989126519",["2026-05-23T08:24:54.982100058",0,113,4]]
+["2026-05-25T09:39:57.99` // intentionally torn
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, b, c, l, ok := readLastCritMsg(path)
+	if !ok {
+		t.Fatalf("expected to recover from torn last line")
+	}
+	if b != 0 || c != 113 || l != 4 {
+		t.Errorf("expected 0/113/4 from preceding line, got %d/%d/%d", b, c, l)
+	}
+}

--- a/internal/monitors/disk_monitor.go
+++ b/internal/monitors/disk_monitor.go
@@ -1,0 +1,130 @@
+package monitors
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// diskPollInterval is intentionally slow: walking NODE_HOME can be many
+// thousands of inodes and a full disk doesn't change in seconds. statfs
+// is cheap but the recursive size walk dominates.
+const diskPollInterval = 60 * time.Second
+
+// trackedSubdirs is the allowlist of subpaths whose recursive byte usage
+// the monitor publishes individually. These are the directories most
+// likely to consume runaway disk on a Hyperliquid node. The list
+// includes both broad rollups (hyperliquid_data, data/replica_cmds)
+// and per-RocksDB subpaths so operators can tell *which* DB is
+// bloating without ssh'ing in.
+var trackedSubdirs = []string{
+	"data/replica_cmds",
+	"data/evm_block_and_receipts",
+	"data/node_logs",
+	"data/latency_buckets",
+	"data/latency_summaries",
+	"data/periodic_abci_states",
+	"data/visor_abci_states",
+	"data/tcp_traffic",
+	"data/dhs",
+	"hyperliquid_data",
+	"hyperliquid_data/db_hub/Evm",
+	"hyperliquid_data/db_hub/Exchange",
+	"hyperliquid_data/db_hub/Rpc",
+	"hyperliquid_data/evm_db_hub_fast",
+	"hyperliquid_data/evm_db_hub_slow",
+	"hyperliquid_data/evm_db_hub_slow/checkpoint",
+	"tmp",
+}
+
+// StartDiskMonitor walks NODE_HOME once a minute and publishes its size
+// alongside the host filesystem's free/total. Operators want to know
+// "how much room do I have before this node breaks" without ssh'ing in;
+// disk filling is one of the most common silent failure modes for
+// blockchain nodes.
+func StartDiskMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	if _, err := os.Stat(cfg.NodeHome); err != nil {
+		logger.WarningComponent("disk",
+			"NODE_HOME %s not accessible, disk monitor idle: %v", cfg.NodeHome, err)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("disk", "starting disk monitor for %s (every %s)",
+		cfg.NodeHome, diskPollInterval)
+
+	ticker := time.NewTicker(diskPollInterval)
+	defer ticker.Stop()
+
+	tickDisk(cfg.NodeHome)
+	metrics.MarkMonitorTick("disk")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickDisk(cfg.NodeHome)
+			metrics.MarkMonitorTick("disk")
+		}
+	}
+}
+
+func tickDisk(nodeHome string) {
+	// Filesystem-level numbers come from statfs and don't require walking
+	// the tree, so do them first and unconditionally — even if the tree
+	// walk later fails or is slow, the operator still gets free/total.
+	if stat, err := statfs(nodeHome); err == nil {
+		metrics.HLNodeDiskFreeBytes.Set(float64(stat.Bavail) * float64(stat.Bsize))
+		metrics.HLNodeDiskTotalBytes.Set(float64(stat.Blocks) * float64(stat.Bsize))
+	} else {
+		logger.DebugComponent("disk", "statfs failed: %v", err)
+	}
+
+	total := dirSize(nodeHome)
+	metrics.HLNodeDiskUsedBytes.Set(float64(total))
+
+	for _, sub := range trackedSubdirs {
+		path := filepath.Join(nodeHome, sub)
+		size := dirSize(path)
+		metrics.HLNodeDiskSubdirBytes.WithLabelValues(sub).Set(float64(size))
+	}
+}
+
+// dirSize sums the on-disk sizes of all regular files under root. Returns 0
+// on any error (missing directory, permission denied, etc) — callers treat
+// "doesn't exist" the same as "0 bytes" which is appropriate for
+// the tracked-subdirs allowlist.
+func dirSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries silently
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
+}
+
+func statfs(path string) (*syscall.Statfs_t, error) {
+	var s syscall.Statfs_t
+	if err := syscall.Statfs(path, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/monitors/evm_account_monitor.go
+++ b/internal/monitors/evm_account_monitor.go
@@ -30,7 +30,7 @@ func StartEVMAccountMonitor(ctx context.Context, cfg config.Config, errCh chan<-
 
 	var lastModTime time.Time
 
-	go func() {
+	goSafe("evm_account", func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
@@ -66,7 +66,7 @@ func StartEVMAccountMonitor(ctx context.Context, cfg config.Config, errCh chan<-
 				lastModTime = info.ModTime()
 			}
 		}
-	}()
+	})
 }
 
 // falls back to periodic snapshots if live state is unavailable

--- a/internal/monitors/evm_monitor.go
+++ b/internal/monitors/evm_monitor.go
@@ -68,12 +68,12 @@ func StartEVMMonitor(ctx context.Context, cfg config.Config, errCh chan<- error)
 	}
 
 	// ensure resolver is cleaned up when context is cancelled
-	go func() {
+	goSafe("evm", func() {
 		<-ctx.Done()
 		if contractResolver != nil {
 			contractResolver.Shutdown()
 		}
-	}()
+	})
 
 	// wait for validator status to be determined
 	time.Sleep(60 * time.Second)
@@ -87,7 +87,7 @@ func StartEVMMonitor(ctx context.Context, cfg config.Config, errCh chan<- error)
 	evmDataDir := filepath.Join(cfg.NodeHome, "data/evm_block_and_receipts/hourly")
 	logger.InfoComponent("evm", "Starting unified EVM monitoring in directory: %s", evmDataDir)
 
-	go func() {
+	goSafe("evm", func() {
 		// check if directory exists
 		if _, err := os.Stat(evmDataDir); os.IsNotExist(err) {
 			logger.WarningComponent("evm", "EVM block and receipts directory does not exist: %s", evmDataDir)
@@ -165,7 +165,7 @@ func StartEVMMonitor(ctx context.Context, cfg config.Config, errCh chan<- error)
 				}
 			}
 		}
-	}()
+	})
 }
 
 func processEVMBlockAndReceiptsLine(line string) error {
@@ -266,6 +266,7 @@ func processBlockData(blockData interface{}, isoTimestamp time.Time) (string, er
 
 	// set block height metric
 	metrics.SetEVMBlockHeight(blockNumber)
+	metrics.MarkMonitorTick("evm")
 
 	// determine block type early so we can use it throughout
 	var blockType string
@@ -290,13 +291,20 @@ func processBlockData(blockData interface{}, isoTimestamp time.Time) (string, er
 			metrics.UpdateMaxGasLimit(gasLimit)
 
 			if blockTypeMetricsEnabled {
-				if gasLimit <= 2_000_000 {
+				// Hyperliquid produces blocks at several discrete gas-limit tiers
+				// (2M standard, 3M, 30M big, etc). The "other" bucket used to log
+				// a WARNING per block, which produced sustained log spam since
+				// the 3M tier is common in practice. Categorize known tiers and
+				// keep "other" silent (debug only).
+				switch {
+				case gasLimit <= 2_000_000:
 					blockType = "standard"
-				} else if gasLimit >= 30_000_000 {
+				case gasLimit == 3_000_000:
+					blockType = "small"
+				case gasLimit >= 30_000_000:
 					blockType = "high"
-				} else {
+				default:
 					blockType = "other"
-					logger.WarningComponent("evm", "Unexpected gas limit: %d", gasLimit)
 				}
 				logger.DebugComponent("evm", "Block %d: gasLimit=%d, blockType=%s", blockNumber, gasLimit, blockType)
 			}

--- a/internal/monitors/gossip_connections_monitor.go
+++ b/internal/monitors/gossip_connections_monitor.go
@@ -1,0 +1,163 @@
+package monitors
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// gossipConnectionEvents lists the event tag names the node emits to
+// gossip_connections logs. The mapping was derived from a live mainnet
+// peer's most recent hour-file. New tags appearing in the future will
+// still be counted but will land in an "other" bucket so cardinality
+// stays predictable.
+//
+// Operator semantics:
+//   - rejecting_gossip_stream_max_peers_reached: capacity exhausted!
+//   - error_checking_connection: peer churn / unreliable peers
+//   - verified_gossip_rpc:       healthy handshake (counter rate = arrival rate)
+var gossipConnectionAllowlist = map[string]string{
+	"verified gossip rpc":                          "verified_gossip_rpc",
+	"handle_stream_connection":                     "handle_stream_connection",
+	"performing checks on stream":                  "performing_checks_on_stream",
+	"got tcp greeting":                             "got_tcp_greeting",
+	"error checking connection":                    "error_checking_connection",
+	"rejecting gossip stream because max peers reached": "rejecting_gossip_stream_max_peers_reached",
+}
+
+// gossipConnectionsPollInterval is short because the file is append-only
+// and operators want to see peer-rejection events promptly.
+const gossipConnectionsPollInterval = 10 * time.Second
+
+// StartGossipConnectionsMonitor watches
+// $NODE_HOME/data/node_logs/gossip_connections/hourly. Each line is of
+// the form ["<iso>", ["<event_tag>", {<event_specific_payload>}]]. We
+// extract only the tag and count occurrences, keeping cardinality flat.
+func StartGossipConnectionsMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "node_logs", "gossip_connections", "hourly")
+
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("gossip_connections",
+			"gossip_connections directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("gossip_connections", "watching %s", root)
+
+	var currentFile string
+	var currentOffset int64
+
+	tick := func() {
+		latest, err := latestHourlyFile(root)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				logger.DebugComponent("gossip_connections", "find latest: %v", err)
+			}
+			return
+		}
+		if latest != currentFile {
+			// On startup or rotation, jump to end so we don't replay history
+			// (counters would otherwise spike on every restart).
+			info, err := os.Stat(latest)
+			if err != nil {
+				return
+			}
+			logger.InfoComponent("gossip_connections", "switched to %s (starting at EOF=%d)", latest, info.Size())
+			currentFile = latest
+			currentOffset = info.Size()
+			return
+		}
+		newOffset, n, err := readGossipConnectionEvents(currentFile, currentOffset)
+		if err != nil {
+			logger.DebugComponent("gossip_connections", "read %s: %v", currentFile, err)
+			return
+		}
+		currentOffset = newOffset
+		if n > 0 {
+			metrics.MarkMonitorTick("gossip_connections")
+		}
+	}
+
+	ticker := time.NewTicker(gossipConnectionsPollInterval)
+	defer ticker.Stop()
+	tick()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tick()
+		}
+	}
+}
+
+// readGossipConnectionEvents reads any new bytes appended to path since
+// offset and increments the gauge counter for each parseable event. Returns
+// the new file offset and the number of lines processed.
+func readGossipConnectionEvents(path string, offset int64) (int64, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return offset, 0, err
+	}
+	defer f.Close()
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return offset, 0, err
+	}
+	reader := bufio.NewReaderSize(f, 1<<20)
+	processed := 0
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if event, ok := parseGossipConnectionLine(line); ok {
+				metrics.HLP2PGossipEventsTotal.WithLabelValues(event).Inc()
+				processed++
+			}
+			offset += int64(len(line))
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return offset, processed, err
+		}
+	}
+	return offset, processed, nil
+}
+
+// parseGossipConnectionLine returns the sanitized event-type label, or
+// ok=false when the line is unparseable. Untracked tags are returned as
+// "other" so total event volume is still visible.
+func parseGossipConnectionLine(line []byte) (string, bool) {
+	line = []byte(strings.TrimSpace(string(line)))
+	if len(line) == 0 || line[0] != '[' {
+		return "", false
+	}
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return "", false
+	}
+	var inner []json.RawMessage
+	if err := json.Unmarshal(outer[1], &inner); err != nil || len(inner) < 1 {
+		return "", false
+	}
+	var tag string
+	if err := json.Unmarshal(inner[0], &tag); err != nil {
+		return "", false
+	}
+	if name, known := gossipConnectionAllowlist[tag]; known {
+		return name, true
+	}
+	return "other", true
+}

--- a/internal/monitors/gossip_connections_monitor_test.go
+++ b/internal/monitors/gossip_connections_monitor_test.go
@@ -1,0 +1,72 @@
+package monitors
+
+import (
+	"testing"
+)
+
+func TestParseGossipConnectionLine_KnownEvents(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			"verified gossip rpc",
+			`["2026-05-25T06:59:53.606639758",["verified gossip rpc",{"Ip":"162.19.103.75"}]]`,
+			"verified_gossip_rpc",
+		},
+		{
+			"performing checks on stream",
+			`["2026-05-25T06:59:53.6",["performing checks on stream",{"foo":1}]]`,
+			"performing_checks_on_stream",
+		},
+		{
+			"error checking connection",
+			`["2026-05-25T06:59:53.6",["error checking connection",{"err":"x"}]]`,
+			"error_checking_connection",
+		},
+		{
+			"rejecting gossip stream because max peers reached",
+			`["2026-05-25T06:59:53.6",["rejecting gossip stream because max peers reached",{}]]`,
+			"rejecting_gossip_stream_max_peers_reached",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseGossipConnectionLine([]byte(c.line))
+			if !ok {
+				t.Fatalf("expected ok=true on %q", c.line)
+			}
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseGossipConnectionLine_OtherFallback(t *testing.T) {
+	line := []byte(`["2026-05-25T06:59:53.6",["some new event we have not seen yet",{}]]`)
+	got, ok := parseGossipConnectionLine(line)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got != "other" {
+		t.Errorf("expected 'other', got %q", got)
+	}
+}
+
+func TestParseGossipConnectionLine_Malformed(t *testing.T) {
+	for _, line := range [][]byte{
+		[]byte(""),
+		[]byte("not json"),
+		[]byte("{}"),
+		[]byte(`["only timestamp"]`),
+		[]byte(`["ts", "not an array"]`),
+		[]byte(`["ts", []]`),
+	} {
+		_, ok := parseGossipConnectionLine(line)
+		if ok {
+			t.Errorf("expected fail on %q", line)
+		}
+	}
+}

--- a/internal/monitors/info_probe_monitor.go
+++ b/internal/monitors/info_probe_monitor.go
@@ -1,0 +1,97 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const (
+	infoProbeInterval     = 15 * time.Second
+	infoProbeHTTPTimeout  = 5 * time.Second
+	defaultInfoEndpoint   = "http://127.0.0.1:3001/info"
+	infoProbeRequestBody  = `{"type":"meta"}`
+)
+
+// StartInfoProbeMonitor actively POSTs `{"type":"meta"}` to the node's
+// --serve-info endpoint every infoProbeInterval. A 200 with a non-empty
+// body counts as up; anything else is down and increments the failure
+// counter.
+//
+// This is the only health probe we have that doesn't depend on file
+// mtimes — those can be confused by clock skew or a node that's still
+// alive but stuck writing. A live HTTP response from the node's own RPC
+// stack is much harder to fake.
+func StartInfoProbeMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	url := cfg.InfoEndpointURL
+	if url == "" {
+		url = defaultInfoEndpoint
+	}
+
+	logger.InfoComponent("info_probe", "probing %s every %s", url, infoProbeInterval)
+
+	client := &http.Client{Timeout: infoProbeHTTPTimeout}
+	ticker := time.NewTicker(infoProbeInterval)
+	defer ticker.Stop()
+
+	probeOnce(ctx, client, url)
+	metrics.MarkMonitorTick("info_probe")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			probeOnce(ctx, client, url)
+			metrics.MarkMonitorTick("info_probe")
+		}
+	}
+}
+
+func probeOnce(ctx context.Context, client *http.Client, url string) {
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(infoProbeRequestBody))
+	if err != nil {
+		metrics.HLInfoEndpointUp.Set(0)
+		metrics.HLInfoEndpointFailuresTotal.Inc()
+		logger.DebugComponent("info_probe", "build request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	latency := time.Since(start)
+	metrics.HLInfoEndpointLatencySeconds.Observe(latency.Seconds())
+
+	if err != nil {
+		metrics.HLInfoEndpointUp.Set(0)
+		metrics.HLInfoEndpointFailuresTotal.Inc()
+		logger.DebugComponent("info_probe", "POST %s: %v", url, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read a bounded amount of the body to confirm non-emptiness — but
+	// don't drain the whole response, the /info endpoint returns the
+	// full perp universe and that's wasted bytes for a health check.
+	buf := make([]byte, 64)
+	n, _ := io.ReadFull(resp.Body, buf)
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusOK && n > 0 {
+		metrics.HLInfoEndpointUp.Set(1)
+		metrics.HLInfoEndpointLastSuccessSeconds.Set(float64(time.Now().Unix()))
+		return
+	}
+
+	metrics.HLInfoEndpointUp.Set(0)
+	metrics.HLInfoEndpointFailuresTotal.Inc()
+	logger.DebugComponent("info_probe", "POST %s -> %d body_len=%d", url, resp.StatusCode, n)
+}

--- a/internal/monitors/log_lines_monitor.go
+++ b/internal/monitors/log_lines_monitor.go
@@ -1,0 +1,120 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const logLinesPollInterval = 60 * time.Second
+
+// logTargets enumerates the (stream, level) tuples we expose. The node
+// rotates each daily.
+var logTargets = []struct {
+	stream string
+	level  string
+}{
+	{"infra", "error"},
+	{"infra", "warn"},
+	{"trade", "error"},
+	{"trade", "warn"},
+}
+
+// StartLogLinesMonitor counts lines and bytes in
+// $NODE_HOME/data/log/<stream>/<level>/<YYYYMMDD>. Both files are
+// empty on a healthy node; any non-zero line count is operator-relevant.
+//
+// Modeled as a gauge that resets at the day boundary because the day-file
+// rotation cleanly zeroes the series; treating it as a counter would
+// look like a regression at midnight UTC.
+func StartLogLinesMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "log")
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("log_lines",
+			"log directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("log_lines", "watching %s", root)
+
+	ticker := time.NewTicker(logLinesPollInterval)
+	defer ticker.Stop()
+
+	tickLogLines(root)
+	metrics.MarkMonitorTick("log_lines")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickLogLines(root)
+			metrics.MarkMonitorTick("log_lines")
+		}
+	}
+}
+
+func tickLogLines(root string) {
+	for _, t := range logTargets {
+		dir := filepath.Join(root, t.stream, t.level)
+		path, err := latestDateFile(dir)
+		if err != nil {
+			// Day file rotates at UTC midnight — between rotation and the
+			// node creating the new file, the dir may briefly look empty.
+			// Report zero rather than freeze the gauges at the previous
+			// day's values.
+			metrics.HLNodeLogLinesTotal.WithLabelValues(t.stream, t.level).Set(0)
+			metrics.HLNodeLogBytes.WithLabelValues(t.stream, t.level).Set(0)
+			continue
+		}
+		lines, size, ok := countLinesAndBytes(path)
+		if !ok {
+			continue
+		}
+		metrics.HLNodeLogLinesTotal.WithLabelValues(t.stream, t.level).Set(float64(lines))
+		metrics.HLNodeLogBytes.WithLabelValues(t.stream, t.level).Set(float64(size))
+	}
+}
+
+// countLinesAndBytes returns (number of \n-terminated lines, byte size).
+// Reads the file in 64KiB chunks so a multi-MB log doesn't allocate the
+// full body. Returns ok=false on any IO error.
+func countLinesAndBytes(path string) (int64, int64, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return 0, 0, false
+	}
+	if info.Size() == 0 {
+		return 0, 0, true
+	}
+
+	buf := make([]byte, 64*1024)
+	var lines int64
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			lines += int64(bytes.Count(buf[:n], []byte{'\n'}))
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, 0, false
+		}
+	}
+	return lines, info.Size(), true
+}

--- a/internal/monitors/node_state_monitor.go
+++ b/internal/monitors/node_state_monitor.go
@@ -1,0 +1,113 @@
+package monitors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// nodeStatePollInterval — three single-file reads, none of which change
+// often. 30s is plenty.
+const nodeStatePollInterval = 30 * time.Second
+
+// visorHeightForLag exposes the latest visor height to other monitors
+// (specifically node_state_monitor, which derives blocks_above_freeze
+// from it). The visor monitor calls SetLatestVisorHeight on each tick.
+//
+// Implemented as a plain int64 atomic rather than a channel/mutex because
+// readers want the *most recent* value and dropped updates are fine.
+var visorHeightForLag int64
+
+// SetLatestVisorHeight is called by visor_monitor.tickVisor on each
+// successful sample so node_state_monitor can compute
+// blocks_above_freeze without re-reading the visor JSON itself.
+func SetLatestVisorHeight(h int64) {
+	atomic.StoreInt64(&visorHeightForLag, h)
+}
+
+func latestVisorHeight() int64 { return atomic.LoadInt64(&visorHeightForLag) }
+
+// StartNodeStateMonitor publishes three tiny gauges sourced from single
+// files under $NODE_HOME/hyperliquid_data:
+//
+//   - freeze_abci_height          → hl_visor_freeze_abci_height
+//                                   plus hl_visor_blocks_above_freeze
+//                                   when the visor monitor has reported
+//                                   a current height.
+//   - evm_db_hub_fast/cp_checkpoint_height → hl_evm_db_checkpoint_height{tier="fast"}
+//   - evm_db_hub_slow/cp_checkpoint_height → hl_evm_db_checkpoint_height{tier="slow"}
+//                                            plus hl_evm_db_checkpoint_lag_blocks
+//                                            (fast - slow).
+//
+// Each file holds a single ASCII integer; the cost of reading all three
+// per tick is negligible compared to any other monitor.
+func StartNodeStateMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	freezePath := filepath.Join(cfg.NodeHome, "hyperliquid_data", "freeze_abci_height")
+	fastPath := filepath.Join(cfg.NodeHome, "hyperliquid_data", "evm_db_hub_fast", "cp_checkpoint_height")
+	slowPath := filepath.Join(cfg.NodeHome, "hyperliquid_data", "evm_db_hub_slow", "cp_checkpoint_height")
+
+	logger.InfoComponent("node_state", "watching %s, %s, %s", freezePath, fastPath, slowPath)
+
+	ticker := time.NewTicker(nodeStatePollInterval)
+	defer ticker.Stop()
+
+	tickNodeState(freezePath, fastPath, slowPath)
+	metrics.MarkMonitorTick("node_state")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickNodeState(freezePath, fastPath, slowPath)
+			metrics.MarkMonitorTick("node_state")
+		}
+	}
+}
+
+func tickNodeState(freezePath, fastPath, slowPath string) {
+	if freeze, ok := readSingleInt(freezePath); ok {
+		metrics.HLVisorFreezeAbciHeight.Set(float64(freeze))
+		if h := latestVisorHeight(); h > 0 && h >= freeze {
+			metrics.HLVisorBlocksAboveFreeze.Set(float64(h - freeze))
+		}
+	}
+	fast, fastOK := readSingleInt(fastPath)
+	slow, slowOK := readSingleInt(slowPath)
+	if fastOK {
+		metrics.HLEVMDBCheckpointHeight.WithLabelValues("fast").Set(float64(fast))
+	}
+	if slowOK {
+		metrics.HLEVMDBCheckpointHeight.WithLabelValues("slow").Set(float64(slow))
+	}
+	if fastOK && slowOK {
+		metrics.HLEVMDBCheckpointLagBlocks.Set(float64(fast - slow))
+	}
+}
+
+// readSingleInt parses the entire file as a single ASCII integer. Whitespace
+// (newlines, leading/trailing spaces) is trimmed. Returns ok=false on any
+// IO or parse error — the caller silently skips that gauge for the tick.
+func readSingleInt(path string) (int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/monitors/node_state_monitor_test.go
+++ b/internal/monitors/node_state_monitor_test.go
@@ -1,0 +1,46 @@
+package monitors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadSingleInt(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		content string
+		want    int64
+		ok      bool
+	}{
+		{"plain", "1007295000", 1007295000, true},
+		{"trailing newline", "1009950000\n", 1009950000, true},
+		{"leading whitespace", "  42\n", 42, true},
+		{"empty", "", 0, false},
+		{"non-numeric", "garbage", 0, false},
+		{"float — rejected", "1.5", 0, false}, // must be integer
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(dir, c.name)
+			if err := os.WriteFile(path, []byte(c.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			got, ok := readSingleInt(path)
+			if ok != c.ok {
+				t.Fatalf("ok=%v want %v", ok, c.ok)
+			}
+			if got != c.want {
+				t.Errorf("got %d want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadSingleInt_Missing(t *testing.T) {
+	_, ok := readSingleInt(filepath.Join(t.TempDir(), "no-such-file"))
+	if ok {
+		t.Fatal("expected ok=false on missing file")
+	}
+}

--- a/internal/monitors/operator_config_monitor.go
+++ b/internal/monitors/operator_config_monitor.go
@@ -1,0 +1,68 @@
+package monitors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const operatorConfigPollInterval = 5 * time.Minute
+
+// operatorConfigFiles is the fixed set of operator-edited JSONs under
+// file_mod_time_tracker/. Cardinality is bounded by this list (which we
+// review when hl-node adds new entries).
+var operatorConfigFiles = []string{
+	"crit_msg_ignore.json",
+	"firewall_ips.json",
+	"node_firewall_ips.json",
+	"ip_rate_limiter_alert_config.json",
+	"n_gossip_peers.json",
+}
+
+// StartOperatorConfigMonitor publishes the mtime age of each file under
+// $NODE_HOME/file_mod_time_tracker/. The age is a proxy for "when did
+// the operator last touch this config" — useful in postmortems.
+func StartOperatorConfigMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "file_mod_time_tracker")
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("operator_config",
+			"file_mod_time_tracker directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("operator_config", "watching %s", root)
+
+	ticker := time.NewTicker(operatorConfigPollInterval)
+	defer ticker.Stop()
+
+	tickOperatorConfig(root)
+	metrics.MarkMonitorTick("operator_config")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickOperatorConfig(root)
+			metrics.MarkMonitorTick("operator_config")
+		}
+	}
+}
+
+func tickOperatorConfig(root string) {
+	now := time.Now()
+	for _, f := range operatorConfigFiles {
+		info, err := os.Stat(filepath.Join(root, f))
+		if err != nil {
+			continue
+		}
+		metrics.HLNodeOperatorConfigAgeSeconds.WithLabelValues(f).
+			Set(now.Sub(info.ModTime()).Seconds())
+	}
+}

--- a/internal/monitors/parent_peer_monitor.go
+++ b/internal/monitors/parent_peer_monitor.go
@@ -1,0 +1,96 @@
+package monitors
+
+import (
+	"context"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// parentPeerPollInterval matches the tcp_traffic cadence; there's nothing
+// new to look at until the source monitor publishes a fresh snapshot.
+const parentPeerPollInterval = 30 * time.Second
+
+// parentPeerAmbiguityThreshold is the fraction of the top peer's bytes the
+// runner-up must exceed before we log a warning about an ambiguous parent.
+// 0.1 = "runner-up is within 10× ratio of the top". A healthy parent
+// relationship has a clear winner (often 100x the runner-up); ambiguity
+// usually means the node has lost its primary or is bridging two.
+const parentPeerAmbiguityThreshold = 0.1
+
+// StartParentPeerMonitor identifies which inbound peer is delivering the
+// most bytes — for a non-validator, that's the node's effective upstream
+// data source ("parent peer"). The metric set lets operators alert on
+// rapid parent switches (potential connectivity issues) and on parent
+// peer loss.
+//
+// Inspired by dwellir-public/hyperliquid-exporter's parent_peer_monitor.
+// Our implementation reuses the shared sample from tcp_traffic_monitor
+// rather than reading tcp_traffic itself a second time.
+func StartParentPeerMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	logger.InfoComponent("parent_peer", "starting parent peer monitor (depends on tcp_traffic sample)")
+
+	var currentParent string
+	var parentSince time.Time
+
+	ticker := time.NewTicker(parentPeerPollInterval)
+	defer ticker.Stop()
+
+	tick := func() {
+		ts, in, _ := LatestTCPTrafficSnapshot()
+		if ts.IsZero() || len(in) == 0 {
+			return
+		}
+
+		top := in[0]
+		var runner peerSample
+		if len(in) > 1 {
+			runner = in[1]
+		}
+
+		if top.value > 0 && runner.value > top.value*parentPeerAmbiguityThreshold {
+			logger.WarningComponent("parent_peer",
+				"ambiguous parent peer: top=%s (%.4g) runner-up=%s (%.4g)",
+				top.ip, top.value, runner.ip, runner.value)
+		}
+
+		now := time.Now()
+		if top.ip != currentParent {
+			if currentParent != "" {
+				metrics.HLNodeParentPeerInfo.DeleteLabelValues(currentParent)
+				metrics.HLNodeParentPeerSwitches.Inc()
+				logger.InfoComponent("parent_peer", "parent peer changed: %s -> %s", currentParent, top.ip)
+			} else {
+				logger.InfoComponent("parent_peer", "initial parent peer: %s", top.ip)
+			}
+			currentParent = top.ip
+			parentSince = now
+		}
+
+		metrics.HLNodeParentPeerInfo.WithLabelValues(top.ip).Set(1)
+		metrics.HLNodeParentPeerTraffic.Set(top.value)
+		metrics.HLNodeParentPeerTenureSeconds.Set(now.Sub(parentSince).Seconds())
+		metrics.MarkMonitorTick("parent_peer")
+	}
+
+	// Wait briefly for the tcp_traffic monitor to publish its first sample
+	// before we tick — otherwise the first iteration is wasted on an empty
+	// snapshot.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(2 * time.Second):
+	}
+
+	tick()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tick()
+		}
+	}
+}

--- a/internal/monitors/process_monitor.go
+++ b/internal/monitors/process_monitor.go
@@ -1,0 +1,87 @@
+package monitors
+
+import (
+	"context"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// processNames are the hl- processes we look up via /proc. Both run on
+// validator and non-validator nodes; on container deployments either may
+// be absent. The monitor publishes hl_node_process_up=0 for missing ones
+// so operators can alert on "expected hl-node process not running".
+var processNames = []string{"hl-node", "hl-visor"}
+
+// processPollInterval is short because operators want quick detection of
+// hl-node crashes — restart-loop monitoring is one of the canonical
+// reasons to run this exporter.
+const processPollInterval = 15 * time.Second
+
+// StartProcessMonitor publishes resource usage and liveness for each
+// known hl- process. The implementation is Linux-only; on darwin/macOS
+// (or any OS without /proc) the monitor logs once and idles.
+func StartProcessMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	if !procFSAvailable() {
+		logger.InfoComponent("process",
+			"process monitor disabled: /proc not available on this OS")
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("process", "watching %v via /proc", processNames)
+
+	ticker := time.NewTicker(processPollInterval)
+	defer ticker.Stop()
+
+	tickProcesses()
+	metrics.MarkMonitorTick("process")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickProcesses()
+			metrics.MarkMonitorTick("process")
+		}
+	}
+}
+
+func tickProcesses() {
+	for _, name := range processNames {
+		info, ok := findProcess(name)
+		if !ok {
+			metrics.HLNodeProcessUp.WithLabelValues(name).Set(0)
+			// Reset companion gauges to zero so a crash is visible on the
+			// dashboard rather than showing the last live value forever.
+			metrics.HLNodeProcessStartTimeSeconds.WithLabelValues(name).Set(0)
+			metrics.HLNodeProcessCPUSecondsTotal.WithLabelValues(name).Set(0)
+			metrics.HLNodeProcessRSSBytes.WithLabelValues(name).Set(0)
+			metrics.HLNodeProcessVirtBytes.WithLabelValues(name).Set(0)
+			metrics.HLNodeProcessThreads.WithLabelValues(name).Set(0)
+			metrics.HLNodeProcessOpenFDs.WithLabelValues(name).Set(0)
+			continue
+		}
+		metrics.HLNodeProcessUp.WithLabelValues(name).Set(1)
+		metrics.HLNodeProcessStartTimeSeconds.WithLabelValues(name).Set(float64(info.StartTimeUnix))
+		metrics.HLNodeProcessCPUSecondsTotal.WithLabelValues(name).Set(info.CPUSeconds)
+		metrics.HLNodeProcessRSSBytes.WithLabelValues(name).Set(float64(info.RSSBytes))
+		metrics.HLNodeProcessVirtBytes.WithLabelValues(name).Set(float64(info.VirtBytes))
+		metrics.HLNodeProcessThreads.WithLabelValues(name).Set(float64(info.Threads))
+		metrics.HLNodeProcessOpenFDs.WithLabelValues(name).Set(float64(info.OpenFDs))
+	}
+}
+
+// processInfo is the OS-independent view the publisher consumes.
+type processInfo struct {
+	PID           int
+	StartTimeUnix int64
+	CPUSeconds    float64
+	RSSBytes      int64
+	VirtBytes     int64
+	Threads       int64
+	OpenFDs       int64
+}

--- a/internal/monitors/process_monitor_linux.go
+++ b/internal/monitors/process_monitor_linux.go
@@ -1,0 +1,173 @@
+//go:build linux
+
+package monitors
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// procFSAvailable reports whether /proc is mounted as procfs. On Linux this
+// is essentially always true; the check protects against misconfigured
+// containers that hide /proc.
+func procFSAvailable() bool {
+	_, err := os.Stat("/proc/self/stat")
+	return err == nil
+}
+
+// clkTckHz is the kernel timer frequency, fixed at 100 Hz on every shipped
+// Linux x86_64 kernel since the 2.6 days (configurable via CONFIG_HZ but
+// not at runtime). We hardcode 100 rather than shelling out to `getconf
+// CLK_TCK` or cgo'ing sysconf(_SC_CLK_TCK), both of which add a runtime
+// dependency for a constant that's been stable for two decades. If you
+// ever deploy this on a non-stock kernel (CONFIG_HZ_250 / _300 / _1000),
+// CPU-time gauges will scale wrong; document it loud here so a future
+// grep for "clkTckHz" when the numbers look funny.
+const clkTckHz = 100.0
+
+var (
+	btimeOnce sync.Once
+	btime     int64
+)
+
+// readBootTime returns the kernel boot epoch from /proc/stat's "btime" line.
+// Cached after the first successful read since boot time is constant.
+func readBootTime() int64 {
+	btimeOnce.Do(func() {
+		data, err := os.ReadFile("/proc/stat")
+		if err != nil {
+			return
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(line, "btime ") {
+				if v, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, "btime")), 10, 64); err == nil {
+					btime = v
+				}
+				return
+			}
+		}
+	})
+	return btime
+}
+
+// findProcess walks /proc, parsing each comm entry, returning the first
+// process whose /proc/PID/comm matches the supplied name. Returns
+// ok=false if no match. Matching against `comm` (the binary basename
+// truncated to 15 chars) is exact and avoids false positives from
+// processes that happen to mention the name in their args.
+func findProcess(name string) (processInfo, bool) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processInfo{}, false
+	}
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		commPath := filepath.Join("/proc", e.Name(), "comm")
+		comm, err := os.ReadFile(commPath)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(comm)) != name {
+			continue
+		}
+		info, ok := readProcessInfo(pid)
+		if !ok {
+			continue
+		}
+		return info, true
+	}
+	return processInfo{}, false
+}
+
+// readProcessInfo gathers the metric values from /proc/PID. Each subfield
+// read is best-effort: failures degrade gracefully to zero rather than
+// dropping the entire process from the metrics.
+func readProcessInfo(pid int) (processInfo, bool) {
+	dir := filepath.Join("/proc", strconv.Itoa(pid))
+
+	info := processInfo{PID: pid}
+
+	// /proc/PID/stat layout per proc(5). Fields are space-separated except
+	// for field 2 (comm) which is bracketed and may contain spaces. Skip
+	// past the bracketed comm and parse the rest as ordered tokens.
+	statRaw, err := os.ReadFile(filepath.Join(dir, "stat"))
+	if err != nil {
+		return info, false
+	}
+	closeBracket := bytes.LastIndexByte(statRaw, ')')
+	if closeBracket < 0 {
+		return info, false
+	}
+	tail := strings.TrimSpace(string(statRaw[closeBracket+1:]))
+	fields := strings.Fields(tail)
+	// After (comm), field offsets shift: original field 3 (state) is now [0].
+	//   utime     = original field 14 → tail index 11
+	//   stime     = original field 15 → tail index 12
+	//   starttime = original field 22 → tail index 19
+	if len(fields) >= 20 {
+		utime, _ := strconv.ParseInt(fields[11], 10, 64)
+		stime, _ := strconv.ParseInt(fields[12], 10, 64)
+		info.CPUSeconds = float64(utime+stime) / clkTckHz
+
+		starttimeTicks, _ := strconv.ParseInt(fields[19], 10, 64)
+		bt := readBootTime()
+		if bt > 0 && clkTckHz > 0 {
+			info.StartTimeUnix = bt + int64(float64(starttimeTicks)/clkTckHz)
+		}
+	}
+
+	// /proc/PID/status for human-friendly memory + threads.
+	statusRaw, err := os.ReadFile(filepath.Join(dir, "status"))
+	if err == nil {
+		for _, line := range strings.Split(string(statusRaw), "\n") {
+			switch {
+			case strings.HasPrefix(line, "VmRSS:"):
+				info.RSSBytes = parseStatusKB(line)
+			case strings.HasPrefix(line, "VmSize:"):
+				info.VirtBytes = parseStatusKB(line)
+			case strings.HasPrefix(line, "Threads:"):
+				info.Threads = parseStatusInt(line)
+			}
+		}
+	}
+
+	// /proc/PID/fd is a directory containing one entry per open FD.
+	if fdEntries, err := os.ReadDir(filepath.Join(dir, "fd")); err == nil {
+		info.OpenFDs = int64(len(fdEntries))
+	}
+
+	return info, true
+}
+
+// parseStatusKB extracts the numeric prefix from a /proc/PID/status line
+// like "VmRSS:    12345 kB" and returns the value in bytes.
+func parseStatusKB(line string) int64 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	n, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n * 1024
+}
+
+func parseStatusInt(line string) int64 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	n, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/monitors/process_monitor_other.go
+++ b/internal/monitors/process_monitor_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package monitors
+
+// Non-Linux stub. /proc-based process metrics are only useful on Linux,
+// which is where production node operators run hl-node. On darwin (the
+// development OS) and other systems the monitor stays idle.
+
+func procFSAvailable() bool { return false }
+
+func findProcess(_ string) (processInfo, bool) { return processInfo{}, false }

--- a/internal/monitors/proposal_monitor.go
+++ b/internal/monitors/proposal_monitor.go
@@ -17,7 +17,7 @@ import (
 )
 
 func StartProposalMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
-	go func() {
+	goSafe("proposal", func() {
 		// skip if replica monitoring is enabled as it will handle proposer counting
 		if cfg.EnableReplicaMetrics {
 			// already logged in exporter.go, just return silently
@@ -103,7 +103,7 @@ func StartProposalMonitor(ctx context.Context, cfg config.Config, errCh chan<- e
 				}
 			}
 		}
-	}()
+	})
 }
 
 func parseProposalLine(ctx context.Context, line string) error {

--- a/internal/monitors/public_ip_monitor.go
+++ b/internal/monitors/public_ip_monitor.go
@@ -1,0 +1,102 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const publicIPPollInterval = 60 * time.Second
+
+// StartPublicIPMonitor watches $NODE_HOME/last_known_public_ip.json.
+// The file is a single JSON-encoded string, e.g. "160.202.131.51", and
+// hl-node rewrites it every ~13 minutes as a heartbeat (with the same
+// value if nothing changed). Three signals:
+//
+//   - the literal IP, as a label on hl_node_public_ip_info{ip="..."} == 1
+//   - the file's mtime age, as hl_node_public_ip_age_seconds
+//   - a counter that ticks every time the content changes
+func StartPublicIPMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	path := filepath.Join(cfg.NodeHome, "last_known_public_ip.json")
+	if _, err := os.Stat(path); err != nil {
+		logger.InfoComponent("public_ip",
+			"last_known_public_ip.json not present (%s); monitor idle", path)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("public_ip", "watching %s", path)
+
+	var currentIP string
+	ticker := time.NewTicker(publicIPPollInterval)
+	defer ticker.Stop()
+
+	tickPublicIP(path, &currentIP)
+	metrics.MarkMonitorTick("public_ip")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickPublicIP(path, &currentIP)
+			metrics.MarkMonitorTick("public_ip")
+		}
+	}
+}
+
+func tickPublicIP(path string, currentIP *string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	metrics.HLNodePublicIPAgeSeconds.Set(time.Since(info.ModTime()).Seconds())
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	ip, ok := parsePublicIP(data)
+	if !ok || ip == "" {
+		return
+	}
+	if ip == *currentIP {
+		return
+	}
+	if *currentIP != "" {
+		metrics.HLNodePublicIPInfo.DeleteLabelValues(*currentIP)
+		metrics.HLNodePublicIPChangesTotal.Inc()
+		logger.InfoComponent("public_ip", "public IP changed: %s -> %s", *currentIP, ip)
+	} else {
+		logger.InfoComponent("public_ip", "initial public IP: %s", ip)
+	}
+	*currentIP = ip
+	metrics.HLNodePublicIPInfo.WithLabelValues(ip).Set(1)
+}
+
+// parsePublicIP accepts either a JSON-encoded string (the canonical
+// representation hl-node uses, e.g. `"160.202.131.51"`) or a bare string
+// without quotes (defensive — the format could plausibly drift).
+func parsePublicIP(data []byte) (string, bool) {
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return "", false
+	}
+	var ip string
+	if err := json.Unmarshal([]byte(s), &ip); err == nil {
+		return ip, true
+	}
+	// Fall back: strip wrapping quotes if any, return whatever's left.
+	s = strings.Trim(s, "\"'")
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/internal/monitors/public_ip_monitor_test.go
+++ b/internal/monitors/public_ip_monitor_test.go
@@ -1,0 +1,30 @@
+package monitors
+
+import "testing"
+
+func TestParsePublicIP(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want string
+		ok   bool
+	}{
+		{"json-string", `"160.202.131.51"`, "160.202.131.51", true},
+		{"json-string with trailing newline", "\"1.2.3.4\"\n", "1.2.3.4", true},
+		{"bare string", "1.2.3.4", "1.2.3.4", true},
+		{"quoted bare", "'5.6.7.8'", "5.6.7.8", true},
+		{"empty", "", "", false},
+		{"whitespace only", "   \n", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parsePublicIP([]byte(c.data))
+			if ok != c.ok {
+				t.Fatalf("ok=%v want %v (data %q)", ok, c.ok, c.data)
+			}
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/monitors/replica_monitor.go
+++ b/internal/monitors/replica_monitor.go
@@ -58,7 +58,7 @@ func NewReplicaMonitor(dataDir string, bufferSize int) *ReplicaMonitor {
 func (m *ReplicaMonitor) Start(ctx context.Context) error {
 	logger.InfoComponent("replica", "Starting streaming replica monitor, dataDir: %s", m.dataDir)
 
-	go m.streamLoop(ctx)
+	goSafe("replica", func() { m.streamLoop(ctx) })
 	return nil
 }
 
@@ -289,6 +289,7 @@ func (m *ReplicaMonitor) processBlock(block *replica.BlockMetrics) {
 	// also update implementation-specific metrics
 	metrics.SetReplicaLastProcessedRound(float64(block.Round))
 	metrics.SetReplicaLastProcessedTime(float64(block.Time.Unix()))
+	metrics.MarkMonitorTick("replica")
 }
 
 // returns current statistics

--- a/internal/monitors/replica_runs_monitor.go
+++ b/internal/monitors/replica_runs_monitor.go
@@ -1,0 +1,86 @@
+package monitors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// replicaRunsPollInterval — these dirs change only on hl-node startup,
+// so a slow tick is fine.
+const replicaRunsPollInterval = 60 * time.Second
+
+// StartReplicaRunsMonitor publishes filesystem-observable hl-node run
+// tracking. The data/replica_cmds/ directory contains one
+// `<run_timestamp>/` subdirectory per hl-node startup; counting them
+// gives the lifetime run count, and the newest mtime gives the current
+// run's start time.
+//
+// This is a deliberate redundancy with the /proc-based process monitor:
+//
+//   - process_monitor reads /proc/PID/stat — most accurate, Linux-only,
+//     fails in containerized deploys where /proc isn't visible.
+//   - replica_runs reads the data directory hl-node writes to anyway —
+//     less precise (5s mkdir granularity, not the actual process clock)
+//     but works in any environment that can read NODE_HOME.
+//
+// Both publish at the same logical metric tier so dashboards can fall
+// back gracefully when one source is unavailable.
+func StartReplicaRunsMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "replica_cmds")
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("replica_runs",
+			"replica_cmds directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("replica_runs", "watching %s", root)
+
+	ticker := time.NewTicker(replicaRunsPollInterval)
+	defer ticker.Stop()
+
+	tickReplicaRuns(root)
+	metrics.MarkMonitorTick("replica_runs")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickReplicaRuns(root)
+			metrics.MarkMonitorTick("replica_runs")
+		}
+	}
+}
+
+func tickReplicaRuns(root string) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	var count int
+	var newestMtime time.Time
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		count++
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if mt := info.ModTime(); mt.After(newestMtime) {
+			newestMtime = mt
+		}
+	}
+	metrics.HLNodeObservedRunsTotal.Set(float64(count))
+	if !newestMtime.IsZero() {
+		metrics.HLNodeObservedRunStartSeconds.Set(float64(newestMtime.Unix()))
+	}
+}

--- a/internal/monitors/rocksdb_monitor.go
+++ b/internal/monitors/rocksdb_monitor.go
@@ -1,0 +1,260 @@
+package monitors
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// rocksDBs is the allowlist of RocksDB directories under hyperliquid_data
+// that we report on. These are the same databases the disk monitor
+// reports sizes for; here we go further and parse the LOG file for
+// LSM-tree health.
+//
+// `name` is the metric label; `relPath` is the path under cfg.NodeHome.
+// We deliberately skip db_hub/Evm and db_hub/Exchange because they're
+// memtable-only on this node (no SSTs, LOG never updates).
+var rocksDBs = []struct {
+	name    string
+	relPath string
+}{
+	{"db_hub_rpc", "hyperliquid_data/db_hub/Rpc"},
+	{"evm_db_fast", "hyperliquid_data/evm_db_hub_fast/EvmState"},
+	{"evm_db_slow", "hyperliquid_data/evm_db_hub_slow/EvmState"},
+}
+
+const (
+	rocksDBPollInterval = 60 * time.Second
+	// rocksDBLogTailBytes is the tail window we read from each LOG file.
+	// RocksDB writes a DUMPING STATS block roughly every 10 minutes, and
+	// the block itself is ~5 KB. 256 KiB comfortably contains the latest
+	// one even after many compaction events between stat dumps.
+	rocksDBLogTailBytes = 256 * 1024
+)
+
+// StartRocksDBMonitor publishes per-database LSM-tree health metrics:
+//
+//   - hl_rocksdb_sst_files{db}              — total .sst file count on disk
+//   - hl_rocksdb_write_stalls_total{db, reason} — write-stall counters
+//     parsed from the LOG (modeled as gauges; resets on hl-node restart)
+//   - hl_rocksdb_block_cache_usage_bytes{db} — current block-cache usage
+//
+// Write stalls are the textbook LSM-tree "falling behind" signal. A
+// non-zero growth rate on `pending-compaction-bytes-stops` for the
+// `db_hub_rpc` DB means RPC writes are blocked while waiting for
+// compaction to catch up — the node will appear sluggish to clients
+// while its disk is fine on the surface.
+func StartRocksDBMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	logger.InfoComponent("rocksdb", "watching %d RocksDB instances", len(rocksDBs))
+
+	ticker := time.NewTicker(rocksDBPollInterval)
+	defer ticker.Stop()
+
+	tickRocksDB(cfg.NodeHome)
+	metrics.MarkMonitorTick("rocksdb")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickRocksDB(cfg.NodeHome)
+			metrics.MarkMonitorTick("rocksdb")
+		}
+	}
+}
+
+func tickRocksDB(nodeHome string) {
+	for _, db := range rocksDBs {
+		dir := filepath.Join(nodeHome, db.relPath)
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+
+		metrics.HLRocksDBSSTFiles.WithLabelValues(db.name).Set(float64(countSSTFiles(dir)))
+
+		logPath := filepath.Join(dir, "LOG")
+		stats, ok := readRocksDBStats(logPath)
+		if !ok {
+			continue
+		}
+		for reason, count := range stats.writeStalls {
+			metrics.HLRocksDBWriteStallsTotal.WithLabelValues(db.name, reason).Set(float64(count))
+		}
+		if stats.cacheUsageBytes >= 0 {
+			metrics.HLRocksDBBlockCacheUsageBytes.WithLabelValues(db.name).Set(float64(stats.cacheUsageBytes))
+		}
+	}
+}
+
+func countSSTFiles(dir string) int {
+	var n int
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".sst") {
+			n++
+		}
+		return nil
+	})
+	return n
+}
+
+type rocksDBStats struct {
+	writeStalls     map[string]int64
+	cacheUsageBytes int64 // -1 if unparsed
+}
+
+// readRocksDBStats tail-reads a RocksDB LOG file, locates the LAST
+// "DUMPING STATS" block, and extracts the write-stall counters and
+// block cache usage. Returns ok=false if no stats block is found in
+// the tail window or if the file can't be read.
+func readRocksDBStats(path string) (rocksDBStats, bool) {
+	stats := rocksDBStats{
+		writeStalls:     map[string]int64{},
+		cacheUsageBytes: -1,
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return stats, false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return stats, false
+	}
+	start := info.Size() - rocksDBLogTailBytes
+	if start < 0 {
+		start = 0
+	}
+	if _, err := f.Seek(start, 0); err != nil {
+		return stats, false
+	}
+	buf := make([]byte, info.Size()-start)
+	if _, err := f.Read(buf); err != nil {
+		return stats, false
+	}
+
+	// Locate the last DUMPING STATS marker.
+	const marker = "------- DUMPING STATS -------"
+	idx := strings.LastIndex(string(buf), marker)
+	if idx < 0 {
+		return stats, false
+	}
+	tail := string(buf[idx:])
+
+	// The two signals we care about often appear on the SAME LINE in
+	// real LOGs — RocksDB writes the long "Write Stall (count): ..."
+	// line and tacks "Block cache LRUCache@... usage: X" onto the end.
+	// Don't switch; check both predicates per line.
+	for _, line := range strings.Split(tail, "\n") {
+		if strings.Contains(line, "Write Stall (count):") {
+			parseWriteStallLine(line, stats.writeStalls)
+		}
+		if strings.Contains(line, "Block cache LRUCache") {
+			if v := parseBlockCacheUsage(line); v >= 0 {
+				stats.cacheUsageBytes = v
+			}
+		}
+	}
+	if len(stats.writeStalls) == 0 && stats.cacheUsageBytes < 0 {
+		return stats, false
+	}
+	return stats, true
+}
+
+// parseWriteStallLine parses tokens of the form `k: v` from a Write
+// Stall line. Both the long combined line and the short
+// write-buffer-manager line follow this shape, so we merge their keys
+// into the same map.
+//
+//	Write Stall (count): cf-l0-file-count-limit-delays-with-ongoing-compaction: 0, ...
+func parseWriteStallLine(line string, out map[string]int64) {
+	// Strip the prefix up to and including the colon after "(count)".
+	prefix := "Write Stall (count):"
+	body := strings.TrimSpace(line[strings.Index(line, prefix)+len(prefix):])
+	for _, part := range strings.Split(body, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		// Stop at the first token that isn't `key: value` — the long line
+		// trails into "Block cache LRUCache@..." past the stall counters.
+		colon := strings.Index(part, ":")
+		if colon < 0 {
+			break
+		}
+		key := strings.TrimSpace(part[:colon])
+		val := strings.TrimSpace(part[colon+1:])
+		// `val` may be just an integer, or it may be the start of a
+		// non-stall token (Block cache...). Try to parse it as int; if
+		// that fails, stop processing.
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			break
+		}
+		if isStallReason(key) {
+			out[key] = n
+		}
+	}
+}
+
+// isStallReason filters the keys to the actual stall counters. Keeps
+// the metric cardinality clean even if RocksDB sneaks new keys into
+// the line in a future version.
+func isStallReason(k string) bool {
+	switch k {
+	case "cf-l0-file-count-limit-delays-with-ongoing-compaction",
+		"cf-l0-file-count-limit-stops-with-ongoing-compaction",
+		"l0-file-count-limit-delays",
+		"l0-file-count-limit-stops",
+		"memtable-limit-delays",
+		"memtable-limit-stops",
+		"pending-compaction-bytes-delays",
+		"pending-compaction-bytes-stops",
+		"total-delays",
+		"total-stops",
+		"write-buffer-manager-limit-stops":
+		return true
+	}
+	return false
+}
+
+// parseBlockCacheUsage extracts the `usage:` value from a Block cache
+// line, e.g. "Block cache LRUCache@0x... capacity: 16.00 GB usage: 172.18 MB".
+// Returns -1 on parse failure.
+var cacheUsageRe = regexp.MustCompile(`usage:\s*([0-9.]+)\s*(KB|MB|GB|B)`)
+
+func parseBlockCacheUsage(line string) int64 {
+	m := cacheUsageRe.FindStringSubmatch(line)
+	if len(m) < 3 {
+		return -1
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return -1
+	}
+	switch m[2] {
+	case "B":
+		return int64(v)
+	case "KB":
+		return int64(v * 1024)
+	case "MB":
+		return int64(v * 1024 * 1024)
+	case "GB":
+		return int64(v * 1024 * 1024 * 1024)
+	}
+	return -1
+}

--- a/internal/monitors/rocksdb_monitor_test.go
+++ b/internal/monitors/rocksdb_monitor_test.go
@@ -1,0 +1,107 @@
+package monitors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseWriteStallLine(t *testing.T) {
+	// Real line trimmed from a hl-node RocksDB LOG. Note the trailing
+	// "Block cache" content — must NOT bleed into the stall counters.
+	line := `Write Stall (count): cf-l0-file-count-limit-delays-with-ongoing-compaction: 0, cf-l0-file-count-limit-stops-with-ongoing-compaction: 0, l0-file-count-limit-delays: 0, l0-file-count-limit-stops: 5, memtable-limit-delays: 0, memtable-limit-stops: 0, pending-compaction-bytes-delays: 12, pending-compaction-bytes-stops: 0, total-delays: 12, total-stops: 5, Block cache LRUCache@0x7d capacity: 16.00 GB usage: 0.08 KB table_size: 1024 occupancy: 87`
+
+	out := map[string]int64{}
+	parseWriteStallLine(line, out)
+
+	if out["l0-file-count-limit-stops"] != 5 {
+		t.Errorf("got l0-file-count-limit-stops=%d want 5", out["l0-file-count-limit-stops"])
+	}
+	if out["pending-compaction-bytes-delays"] != 12 {
+		t.Errorf("got pending-compaction-bytes-delays=%d want 12", out["pending-compaction-bytes-delays"])
+	}
+	if out["total-stops"] != 5 {
+		t.Errorf("got total-stops=%d want 5", out["total-stops"])
+	}
+	if _, present := out["Block cache LRUCache@0x7d capacity"]; present {
+		t.Errorf("Block cache token should not be counted as a stall reason")
+	}
+	if _, present := out["table_size"]; present {
+		t.Errorf("table_size token should not be counted as a stall reason")
+	}
+}
+
+func TestParseBlockCacheUsage(t *testing.T) {
+	cases := []struct {
+		line string
+		want int64
+	}{
+		{"Block cache LRUCache@0x... capacity: 16.00 GB usage: 0.08 KB table_size: 1024", 81}, // 0.08 * 1024 → 81 (truncated)
+		{"... usage: 172.18 MB ...", 180543815},  // 172.18 * 1024 * 1024 → 180543815 (truncated)
+		{"... usage: 2.5 GB ...", 2684354560},    // 2.5 * 1024^3
+		{"... usage: 4096 B ...", 4096},
+		{"no usage here", -1},
+	}
+	for _, c := range cases {
+		if got := parseBlockCacheUsage(c.line); got != c.want {
+			t.Errorf("line %q: got %d want %d", c.line, got, c.want)
+		}
+	}
+}
+
+func TestReadRocksDBStats_RealSample(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "LOG")
+	// Two DUMPING STATS blocks. The reader should pick the LAST one
+	// (the one with higher counters), not the first.
+	contents := `2026/05/25-11:12:23.794279 3528027 [db/db_impl/db_impl.cc:1084] ------- DUMPING STATS -------
+... random unrelated text ...
+Write Stall (count): l0-file-count-limit-stops: 1, total-stops: 1, Block cache LRUCache@0x1 capacity: 1.00 GB usage: 1.00 KB
+
+2026/05/25-11:22:23.794672 3528027 [db/db_impl/db_impl.cc:1084] ------- DUMPING STATS -------
+some more text
+Write Stall (count): l0-file-count-limit-stops: 9, total-stops: 9, Block cache LRUCache@0x2 capacity: 2.00 GB usage: 5.00 MB
+
+`
+	if err := os.WriteFile(logPath, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stats, ok := readRocksDBStats(logPath)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if stats.writeStalls["l0-file-count-limit-stops"] != 9 {
+		t.Errorf("expected the LAST stats block (=9), got %d", stats.writeStalls["l0-file-count-limit-stops"])
+	}
+	wantCache := int64(5 * 1024 * 1024)
+	if stats.cacheUsageBytes != wantCache {
+		t.Errorf("cache usage: got %d want %d", stats.cacheUsageBytes, wantCache)
+	}
+}
+
+func TestReadRocksDBStats_NoStatsBlock(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "LOG")
+	// Real startup-log content with NO stats block yet.
+	if err := os.WriteFile(logPath, []byte("DB pointer 0x...\nrecovery_started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, ok := readRocksDBStats(logPath)
+	if ok {
+		t.Errorf("expected ok=false when no DUMPING STATS marker present")
+	}
+}
+
+func TestCountSSTFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"foo.sst", "bar.sst", "baz.log", "qux.ldb", "subdir/inner.sst"} {
+		path := filepath.Join(dir, name)
+		_ = os.MkdirAll(filepath.Dir(path), 0o755)
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := countSSTFiles(dir); got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}

--- a/internal/monitors/round_advance_monitor.go
+++ b/internal/monitors/round_advance_monitor.go
@@ -28,7 +28,7 @@ func StartRoundAdvanceMonitor(ctx context.Context, cfg config.Config, errCh chan
 	// logs live under <node_home>/data/node_logs/status/hourly/YYYYMMDD/<hour>
 	statusHourlyRoot := filepath.Join(cfg.NodeHome, "data/node_logs/status/hourly")
 
-	go func() {
+	goSafe("round_advance", func() {
 		var currentFile string
 		var fileReader *bufio.Reader
 		isFirstRun := true
@@ -112,7 +112,7 @@ func StartRoundAdvanceMonitor(ctx context.Context, cfg config.Config, errCh chan
 				}
 			}
 		}
-	}()
+	})
 }
 
 func parseRoundAdvanceLine(line string) error {

--- a/internal/monitors/safego.go
+++ b/internal/monitors/safego.go
@@ -1,0 +1,30 @@
+package monitors
+
+import (
+	"runtime/debug"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// goSafe runs fn in a new goroutine with panic recovery. Monitors that
+// spawn additional internal goroutines (e.g. consensus_monitor launches
+// separate readers for consensus, status, and a housekeeping ticker) must
+// use this rather than a bare `go`; otherwise the outer runMonitor wrapper
+// in the exporter package only protects the top-level call, and a panic
+// in any sub-goroutine kills that subsystem silently for the lifetime of
+// the process.
+//
+// The component name is used both for the structured log entry and to
+// attribute the panic in hl_exporter_monitor_panics_total{monitor=...}.
+func goSafe(component string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				metrics.IncMonitorPanic(component)
+				logger.ErrorComponent(component, "subgoroutine PANIC recovered: %v\n%s", r, debug.Stack())
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/monitors/snapshot_status_monitor.go
+++ b/internal/monitors/snapshot_status_monitor.go
@@ -1,0 +1,109 @@
+package monitors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// snapshotStatusPollInterval matches the underlying ~11-min snapshot
+// cadence at 30s tick; cheap enough to leave at this rate.
+const snapshotStatusPollInterval = 30 * time.Second
+
+// StartSnapshotStatusMonitor watches
+// $NODE_HOME/data/periodic_abci_state_statuses/<YYYYMMDD>/<height>.
+//
+// Each entry is a zero-byte file written by hl-node AFTER the
+// corresponding .rmp snapshot completes successfully. The filename is
+// the block height; the file's mtime is when the snapshot finished. The
+// status sentinel outlives the .rmp itself (we observe ~58 statuses
+// retained vs ~37 .rmps), so this directory is the right source for
+// "when did the last snapshot succeed".
+//
+// Operator alert: hl_node_snapshot_last_age_seconds > 15m means the
+// snapshot pipeline has stalled.
+func StartSnapshotStatusMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "periodic_abci_state_statuses")
+
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("snapshot_status",
+			"periodic_abci_state_statuses directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("snapshot_status", "watching %s", root)
+
+	ticker := time.NewTicker(snapshotStatusPollInterval)
+	defer ticker.Stop()
+
+	tickSnapshotStatus(root)
+	metrics.MarkMonitorTick("snapshot_status")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickSnapshotStatus(root)
+			metrics.MarkMonitorTick("snapshot_status")
+		}
+	}
+}
+
+func tickSnapshotStatus(root string) {
+	// Latest date directory.
+	dateEntries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	var latestDate string
+	for _, e := range dateEntries {
+		if !e.IsDir() {
+			continue
+		}
+		if e.Name() > latestDate {
+			latestDate = e.Name()
+		}
+	}
+	if latestDate == "" {
+		return
+	}
+	dateDir := filepath.Join(root, latestDate)
+
+	hgtEntries, err := os.ReadDir(dateDir)
+	if err != nil {
+		return
+	}
+	var maxHeight int64
+	var maxMtime time.Time
+	count := 0
+	for _, e := range hgtEntries {
+		h, err := strconv.ParseInt(e.Name(), 10, 64)
+		if err != nil {
+			continue
+		}
+		count++
+		if h > maxHeight {
+			maxHeight = h
+		}
+		if info, err := e.Info(); err == nil {
+			if mt := info.ModTime(); mt.After(maxMtime) {
+				maxMtime = mt
+			}
+		}
+	}
+	if maxHeight > 0 {
+		metrics.HLNodeSnapshotLastHeight.Set(float64(maxHeight))
+	}
+	if !maxMtime.IsZero() {
+		metrics.HLNodeSnapshotLastAgeSeconds.Set(time.Since(maxMtime).Seconds())
+	}
+	metrics.HLNodeSnapshotKnown.Set(float64(count))
+}

--- a/internal/monitors/subsystem_latency_monitor.go
+++ b/internal/monitors/subsystem_latency_monitor.go
@@ -1,0 +1,206 @@
+package monitors
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// subsystemAllowlist is the set of hl-node internal subsystems we expose
+// as Prometheus series. Capped explicitly to avoid label-cardinality
+// surprises if new subsystems appear under latency_summaries/. Operators
+// should care primarily about block-production-path latencies and the
+// async runtime observers.
+//
+// Subsystems found on a live mainnet peer (May 2026):
+//   bucket_guard, execution_sender, handle_request_rate_limiter,
+//   node_fast_backlog_from_node, node_fast_begin_block_to_commit,
+//   node_fast_block_duration, node_slow_backlog_from_node,
+//   node_slow_begin_block_to_commit, node_slow_block_duration, proposer,
+//   run_node_compute_resps_hash, tcp_lz4, tokio_scheduled_observer_fast,
+//   tokio_scheduled_observer_slow, tokio_spawn_forever_scheduled
+//
+// All of these are useful for an operator dashboard; the allowlist is
+// here as an explicit ceiling rather than to filter known noise.
+var subsystemAllowlist = map[string]bool{
+	"bucket_guard":                    true,
+	"execution_sender":                true,
+	"handle_request_rate_limiter":     true,
+	"node_fast_backlog_from_node":     true,
+	"node_fast_begin_block_to_commit": true,
+	"node_fast_block_duration":        true,
+	"node_slow_backlog_from_node":     true,
+	"node_slow_begin_block_to_commit": true,
+	"node_slow_block_duration":        true,
+	"proposer":                        true,
+	"run_node_compute_resps_hash":     true,
+	"tcp_lz4":                         true,
+	"tokio_scheduled_observer_fast":   true,
+	"tokio_scheduled_observer_slow":   true,
+	"tokio_spawn_forever_scheduled":   true,
+}
+
+// latencySummary mirrors one JSON line under latency_summaries/<sub>/<date>.
+// Fields are floats representing seconds.
+type latencySummary struct {
+	Time          string  `json:"time"`
+	TotalN        int64   `json:"total_n"`
+	TotalMean     float64 `json:"total_mean"`
+	Mean          float64 `json:"mean"`
+	Median        float64 `json:"med"`
+	P90           float64 `json:"p90"`
+	P95           float64 `json:"p95"`
+	Max           float64 `json:"max"`
+	StdDev        float64 `json:"std_dev"`
+	WorkFrac      float64 `json:"work_frac"`
+	BucketWorkFrac float64 `json:"bucket_work_frac"`
+}
+
+const subsystemLatencyPollInterval = 30 * time.Second
+
+// StartSubsystemLatencyMonitor scans $NODE_HOME/data/latency_summaries every
+// subsystemLatencyPollInterval. For each allowlisted subsystem it reads the
+// last record of the newest date-file and publishes that to the
+// subsystem-latency gauges.
+//
+// Reading the last record means restart-tolerance is implicit (each tick
+// re-fetches; no resume state to lose).
+func StartSubsystemLatencyMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "latency_summaries")
+
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("subsystem_latency",
+			"latency_summaries directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("subsystem_latency", "watching %s", root)
+
+	ticker := time.NewTicker(subsystemLatencyPollInterval)
+	defer ticker.Stop()
+
+	tickSubsystemLatency(root)
+	metrics.MarkMonitorTick("subsystem_latency")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickSubsystemLatency(root)
+			metrics.MarkMonitorTick("subsystem_latency")
+		}
+	}
+}
+
+func tickSubsystemLatency(root string) {
+	subDirs, err := os.ReadDir(root)
+	if err != nil {
+		logger.DebugComponent("subsystem_latency", "read root: %v", err)
+		return
+	}
+	for _, sub := range subDirs {
+		if !sub.IsDir() {
+			continue
+		}
+		name := sub.Name()
+		if !subsystemAllowlist[name] {
+			continue
+		}
+		path := filepath.Join(root, name)
+		datePath, err := latestDateFile(path)
+		if err != nil {
+			continue
+		}
+		summary, ok := readLastSummary(datePath)
+		if !ok {
+			continue
+		}
+		publishSubsystemLatency(name, summary)
+	}
+}
+
+// latestDateFile returns the highest-named (lexicographically — which is
+// chronological for YYYYMMDD-prefixed files) entry in dir.
+func latestDateFile(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var best string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if e.Name() > best {
+			best = e.Name()
+		}
+	}
+	if best == "" {
+		return "", os.ErrNotExist
+	}
+	return filepath.Join(dir, best), nil
+}
+
+// readLastSummary returns the last complete JSON record in the file. Reads
+// the tail bytes only (4 KiB is plenty — each record is ~400 bytes) so it
+// is fast for the 1 MB-plus daily files.
+func readLastSummary(path string) (latencySummary, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return latencySummary{}, false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return latencySummary{}, false
+	}
+	const window = 4096
+	start := info.Size() - window
+	if start < 0 {
+		start = 0
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return latencySummary{}, false
+	}
+	buf, err := io.ReadAll(bufio.NewReader(f))
+	if err != nil {
+		return latencySummary{}, false
+	}
+	lines := strings.Split(strings.TrimRight(string(buf), "\n"), "\n")
+	// scan upwards for the last parseable line — guards against a torn
+	// trailing write from the node.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var s latencySummary
+		if err := json.Unmarshal([]byte(line), &s); err == nil {
+			return s, true
+		}
+	}
+	return latencySummary{}, false
+}
+
+func publishSubsystemLatency(subsystem string, s latencySummary) {
+	metrics.HLNodeSubsystemLatencyMean.WithLabelValues(subsystem).Set(s.Mean)
+	metrics.HLNodeSubsystemLatencyMedian.WithLabelValues(subsystem).Set(s.Median)
+	metrics.HLNodeSubsystemLatencyP90.WithLabelValues(subsystem).Set(s.P90)
+	metrics.HLNodeSubsystemLatencyP95.WithLabelValues(subsystem).Set(s.P95)
+	metrics.HLNodeSubsystemLatencyMax.WithLabelValues(subsystem).Set(s.Max)
+	metrics.HLNodeSubsystemLatencyStdDev.WithLabelValues(subsystem).Set(s.StdDev)
+	metrics.HLNodeSubsystemWorkFrac.WithLabelValues(subsystem).Set(s.WorkFrac)
+	metrics.HLNodeSubsystemSamplesTotal.WithLabelValues(subsystem).Set(float64(s.TotalN))
+}

--- a/internal/monitors/subsystem_latency_monitor_test.go
+++ b/internal/monitors/subsystem_latency_monitor_test.go
@@ -1,0 +1,58 @@
+package monitors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadLastSummary_RealSample(t *testing.T) {
+	// Real sample from node_fast_begin_block_to_commit/<date> on a live
+	// mainnet peer.
+	line := `{"time":"2026-05-25T09:57:48.041484537","total_n":522583,"total_mean":0.013836266979599502,"n_buffer":2000,"work_frac":0.20158894558399418,"mean":0.011538491999999997,"med":0.00985,"p90":0.022832,"p95":0.02861,"max":0.053403,"std_dev":0.00799840272010434,"bucket_mean":0.010863827664399103,"bucket_work_frac":0.15968112223684267,"bucket_n":441,"bucket_n_orig":441,"is_subsampled":false}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260525")
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, ok := readLastSummary(path)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if s.Mean != 0.011538491999999997 || s.P95 != 0.02861 || s.TotalN != 522583 {
+		t.Errorf("mismatch: %+v", s)
+	}
+}
+
+func TestReadLastSummary_TornLastLine(t *testing.T) {
+	good := `{"time":"2026-05-25T09:57:48","total_n":1,"mean":1.0,"med":1,"p90":1,"p95":1,"max":1,"std_dev":0,"work_frac":0.1}`
+	torn := `{"time":"2026-05-25T09:58:18","total_n":2,"mea`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260525")
+	if err := os.WriteFile(path, []byte(good+"\n"+torn), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, ok := readLastSummary(path)
+	if !ok {
+		t.Fatal("expected to recover from torn last line")
+	}
+	if s.TotalN != 1 {
+		t.Errorf("expected to read 'good' line, got total_n=%d", s.TotalN)
+	}
+}
+
+func TestLatestDateFile(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"20260524", "20260525", "20260523"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := latestDateFile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got) != "20260525" {
+		t.Errorf("got %q, want suffix 20260525", got)
+	}
+}

--- a/internal/monitors/subsystem_steps_monitor.go
+++ b/internal/monitors/subsystem_steps_monitor.go
@@ -1,0 +1,175 @@
+package monitors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// bucketGuardSteps is the allowlist of bucket_guard sub-steps we expose
+// individually. Mirrors what's on disk under
+// latency_summaries/bucket_guard/<step>/<YYYYMMDD>. Sourced from a
+// live mainnet peer in May 2026.
+var bucketGuardSteps = map[string]bool{
+	"action_delayer_log_status":                  true,
+	"apply_bole_liquidations":                    true,
+	"begin_block":                                true,
+	"build_big_evm_block_and_apply_l1_effects":   true,
+	"build_small_evm_block_and_apply_l1_effects": true,
+	"c_staking_stage_reward":                     true,
+	"cancel_aggressive_orders_at_oi_cap":         true,
+	"decay_staking":                              true,
+	"deterministic_vty_alert_n_bucket_samples":   true,
+	"distribute_funding":                         true,
+	"gas_auction_restart":                        true,
+	"hyperliquidity_ensure_orders":               true,
+	"prune_book_empty_user_states":               true,
+	"refresh_hip3_stale_mark_pxs":                true,
+	"reset_counters":                             true,
+	"reset_recent_ois":                           true,
+	"slow_abci_engine_read_increment":            true,
+	"update_funding_rates":                       true,
+	"validator_l1_vote_tracker_prune_expired":    true,
+}
+
+// tcpLz4Steps is the allowlist of per-direction-per-port lz4 latency
+// sub-steps. Cardinality 4.
+var tcpLz4Steps = map[string]bool{
+	"in_4001":  true,
+	"out_4001": true,
+	"in_4002":  true,
+	"out_4002": true,
+}
+
+const subsystemStepsPollInterval = 60 * time.Second
+
+// StartSubsystemStepsMonitor surfaces the finer-grained latency
+// breakdowns nested under latency_summaries/bucket_guard/<step>/<date>
+// and latency_summaries/tcp_lz4/<step>/<date>. These steps don't
+// appear at the subsystem level — bucket_guard has 19 distinct work
+// items and tcp_lz4 has separate latency profiles per direction-port
+// pair.
+//
+// Operator signal: `bucket_guard.begin_block` p95 may look healthy
+// while max occasionally spikes into seconds — a tail-latency outlier
+// invisible from the rolled-up subsystem stats. Same for the
+// per-port lz4 latencies, which show the 4002 port runs ~10x
+// slower than 4001 (an undocumented quirk worth knowing).
+func StartSubsystemStepsMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	bucketGuardRoot := filepath.Join(cfg.NodeHome, "data", "latency_summaries", "bucket_guard")
+	tcpLz4Root := filepath.Join(cfg.NodeHome, "data", "latency_summaries", "tcp_lz4")
+
+	if _, err := os.Stat(bucketGuardRoot); err != nil {
+		logger.InfoComponent("subsystem_steps",
+			"bucket_guard root not present (%s); monitor idle", bucketGuardRoot)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("subsystem_steps",
+		"watching %s + %s", bucketGuardRoot, tcpLz4Root)
+
+	ticker := time.NewTicker(subsystemStepsPollInterval)
+	defer ticker.Stop()
+
+	tickSubsystemSteps(bucketGuardRoot, tcpLz4Root)
+	metrics.MarkMonitorTick("subsystem_steps")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickSubsystemSteps(bucketGuardRoot, tcpLz4Root)
+			metrics.MarkMonitorTick("subsystem_steps")
+		}
+	}
+}
+
+func tickSubsystemSteps(bucketGuardRoot, tcpLz4Root string) {
+	tickBucketGuard(bucketGuardRoot)
+	tickTCPLz4Steps(tcpLz4Root)
+}
+
+func tickBucketGuard(root string) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !bucketGuardSteps[name] {
+			continue
+		}
+		datePath, err := latestDateFile(filepath.Join(root, name))
+		if err != nil {
+			continue
+		}
+		s, ok := readLastSummary(datePath)
+		if !ok {
+			continue
+		}
+		setBucketGuardQuantiles(name, s)
+	}
+}
+
+func tickTCPLz4Steps(root string) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !tcpLz4Steps[name] {
+			continue
+		}
+		datePath, err := latestDateFile(filepath.Join(root, name))
+		if err != nil {
+			continue
+		}
+		s, ok := readLastSummary(datePath)
+		if !ok {
+			continue
+		}
+		// Split name "in_4001" → direction="in", port="4001".
+		idx := strings.IndexByte(name, '_')
+		if idx <= 0 || idx >= len(name)-1 {
+			continue
+		}
+		direction := name[:idx]
+		port := name[idx+1:]
+		setLz4Quantiles(direction, port, s)
+	}
+}
+
+func setBucketGuardQuantiles(step string, s latencySummary) {
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "p50").Set(s.Median)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "p90").Set(s.P90)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "p95").Set(s.P95)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "max").Set(s.Max)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "mean").Set(s.Mean)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "std_dev").Set(s.StdDev)
+	metrics.HLLatencyBucketGuard.WithLabelValues(step, "work_frac").Set(s.WorkFrac)
+}
+
+func setLz4Quantiles(direction, port string, s latencySummary) {
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "p50").Set(s.Median)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "p90").Set(s.P90)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "p95").Set(s.P95)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "max").Set(s.Max)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "mean").Set(s.Mean)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "std_dev").Set(s.StdDev)
+	metrics.HLTCPLz4Latency.WithLabelValues(direction, port, "work_frac").Set(s.WorkFrac)
+}

--- a/internal/monitors/tcp_connections_monitor.go
+++ b/internal/monitors/tcp_connections_monitor.go
@@ -1,0 +1,79 @@
+package monitors
+
+import (
+	"context"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// tcpConnectionsPollInterval — /proc/net/tcp{,6} are small and cheap to
+// read; polling at 15 s gives near-real-time visibility into peer churn
+// without measurable cost.
+const tcpConnectionsPollInterval = 15 * time.Second
+
+// tcpListenPorts is the fixed set of hl-node listening ports we report
+// state counts for. Confirmed via `ss -tlnp` on a live mainnet peer:
+//
+//	4001 — gossip
+//	4002 — gossip secondary
+//	3999 — --serve-info
+//	3001 — --serve-evm-rpc
+//
+// We only report state counts for connections WHERE OUR SIDE IS ONE OF
+// THESE LISTENING PORTS, so the per-port label has bounded cardinality.
+var tcpListenPorts = []uint16{4001, 4002, 3999, 3001}
+
+// tcpStateNames maps the hex state codes used by /proc/net/tcp to the
+// well-known names. See net/tcp_states.h in the kernel.
+var tcpStateNames = map[uint8]string{
+	0x01: "ESTABLISHED",
+	0x02: "SYN_SENT",
+	0x03: "SYN_RECV",
+	0x04: "FIN_WAIT1",
+	0x05: "FIN_WAIT2",
+	0x06: "TIME_WAIT",
+	0x07: "CLOSE",
+	0x08: "CLOSE_WAIT",
+	0x09: "LAST_ACK",
+	0x0A: "LISTEN",
+	0x0B: "CLOSING",
+}
+
+// StartTCPConnectionsMonitor reports the count of TCP connections on
+// each hl-node listening port, grouped by socket state. Linux-only;
+// no-ops on other OSes through the platform shim file.
+//
+// Operator signal: the "right-now" peer count from ESTABLISHED on 4001
+// is a much truer view than the ~260-peer file snapshot from
+// tcp_traffic_monitor. Sustained TIME_WAIT growth on 4002 (we observed
+// 33 on a live node) indicates peer churn invisible from any other
+// source.
+func StartTCPConnectionsMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	if !procFSAvailable() {
+		logger.InfoComponent("tcp_connections",
+			"tcp_connections monitor disabled: /proc not available on this OS")
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("tcp_connections", "watching /proc/net/tcp{,6}")
+
+	ticker := time.NewTicker(tcpConnectionsPollInterval)
+	defer ticker.Stop()
+
+	tickTCPConnections()
+	metrics.MarkMonitorTick("tcp_connections")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickTCPConnections()
+			metrics.MarkMonitorTick("tcp_connections")
+		}
+	}
+}

--- a/internal/monitors/tcp_connections_monitor_linux.go
+++ b/internal/monitors/tcp_connections_monitor_linux.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package monitors
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// tickTCPConnections reads /proc/net/tcp and /proc/net/tcp6, tallies
+// each listening-port × state pair across both, and updates the
+// hl_p2p_tcp_connections gauge. Any state not seen this tick is set to
+// 0 explicitly so a transition out of (say) TIME_WAIT immediately
+// reflects in the gauge rather than freezing at the last positive
+// value.
+func tickTCPConnections() {
+	counts := make(map[uint16]map[string]int)
+	for _, p := range tcpListenPorts {
+		counts[p] = map[string]int{}
+		// Pre-seed all known states with 0 so we publish a complete grid.
+		for _, name := range tcpStateNames {
+			counts[p][name] = 0
+		}
+	}
+
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		readTCPFile(path, counts)
+	}
+
+	for port, byState := range counts {
+		portLabel := strconv.FormatUint(uint64(port), 10)
+		for state, n := range byState {
+			metrics.HLP2PTCPConnections.WithLabelValues(portLabel, state).Set(float64(n))
+		}
+	}
+}
+
+// readTCPFile parses one of /proc/net/tcp{,6}. Format per line (after
+// the header):
+//
+//	sl  local_address      rem_address    st tx_q rx_q tr tm->w retrnsmt uid timeout inode ...
+//	0:  00000000:0FA1      00000000:0000  0A 00000000:00000000 ...
+//
+// `local_address` is `hex_ip:hex_port`. We tally counts[<localport>][<state>]
+// only if localport is one of our tracked listening ports.
+func readTCPFile(path string, counts map[uint16]map[string]int) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	headerSkipped := false
+	for scanner.Scan() {
+		if !headerSkipped {
+			headerSkipped = true
+			continue
+		}
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		// local_address = "<ip>:<port>" in hex.
+		colon := strings.LastIndexByte(fields[1], ':')
+		if colon < 0 {
+			continue
+		}
+		port64, err := strconv.ParseUint(fields[1][colon+1:], 16, 16)
+		if err != nil {
+			continue
+		}
+		port := uint16(port64)
+		byState, ok := counts[port]
+		if !ok {
+			continue // not a port we care about
+		}
+		state64, err := strconv.ParseUint(fields[3], 16, 8)
+		if err != nil {
+			continue
+		}
+		stateName, known := tcpStateNames[uint8(state64)]
+		if !known {
+			stateName = "UNKNOWN"
+		}
+		byState[stateName]++
+	}
+}

--- a/internal/monitors/tcp_connections_monitor_other.go
+++ b/internal/monitors/tcp_connections_monitor_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package monitors
+
+// /proc/net/tcp is Linux-only. On other platforms the monitor stays
+// idle (gated by procFSAvailable() in the platform-agnostic Start*).
+
+func tickTCPConnections() {}

--- a/internal/monitors/tcp_lz4_monitor.go
+++ b/internal/monitors/tcp_lz4_monitor.go
@@ -1,0 +1,306 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const (
+	tcpLz4PollInterval = 60 * time.Second
+	tcpLz4TopN         = 16
+)
+
+// lz4PeerSample is one peer row from the latest line.
+type lz4PeerSample struct {
+	direction string // "in" / "out"
+	ip        string
+	bytes     int64
+	packets   int64
+	ratio     float64
+}
+
+// StartTCPLz4Monitor watches $NODE_HOME/data/tcp_lz4_stats/<YYYYMMDD>.
+//
+// hl-node writes the file every 5 minutes (300 s sample windows), so a
+// 60-second poll is more than enough; we only re-parse when the file's
+// mtime changed.
+//
+// Each tick yields two records (microseconds apart on the same
+// timestamp):
+//   - a peer-level array:  [ts, [[[dir, ip, port], bytes, packets, ratio], ...]]
+//   - a global aggregate:  [ts, [bytes, packets, ratio]]
+//
+// We take the most recent of each. Per-peer cardinality is capped at
+// tcpLz4TopN per direction with an ip="other" rollup, mirroring the
+// pattern in tcp_traffic_monitor.
+func StartTCPLz4Monitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	path := filepath.Join(cfg.NodeHome, "data", "tcp_lz4_stats")
+	if _, err := os.Stat(path); err != nil {
+		logger.InfoComponent("tcp_lz4",
+			"tcp_lz4_stats directory not present (%s); monitor idle", path)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("tcp_lz4", "watching %s", path)
+
+	prev := map[string]map[string]bool{
+		"in":  {},
+		"out": {},
+	}
+	var lastMtime time.Time
+
+	ticker := time.NewTicker(tcpLz4PollInterval)
+	defer ticker.Stop()
+
+	tickLz4(path, prev, &lastMtime)
+	metrics.MarkMonitorTick("tcp_lz4")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickLz4(path, prev, &lastMtime)
+			metrics.MarkMonitorTick("tcp_lz4")
+		}
+	}
+}
+
+func tickLz4(root string, prev map[string]map[string]bool, lastMtime *time.Time) {
+	datePath, err := latestDateFile(root)
+	if err != nil {
+		return
+	}
+	info, err := os.Stat(datePath)
+	if err != nil {
+		return
+	}
+	if info.ModTime().Equal(*lastMtime) {
+		return // file unchanged
+	}
+	data, err := os.ReadFile(datePath)
+	if err != nil {
+		return
+	}
+
+	// Walk lines from the bottom, classifying each as global or per-peer
+	// until we've found one of each. The two records are written
+	// microseconds apart on every sample, so finding both is the
+	// expected case; we bound the search at maxLinesToScan as a sanity
+	// guard against a pathologically large file from a long uptime.
+	const maxLinesToScan = 64
+	gotGlobal := false
+	gotPeer := false
+	end := len(data)
+	scanned := 0
+	for end > 0 && scanned < maxLinesToScan && (!gotGlobal || !gotPeer) {
+		// Skip trailing newlines.
+		for end > 0 && data[end-1] == '\n' {
+			end--
+		}
+		if end == 0 {
+			break
+		}
+		start := bytes.LastIndexByte(data[:end], '\n') + 1
+		line := bytes.TrimSpace(data[start:end])
+		end = start - 1
+		scanned++
+		if len(line) == 0 || line[0] != '[' {
+			continue
+		}
+		if !gotGlobal {
+			if b, p, r, ok := parseLz4GlobalLine(line); ok {
+				metrics.HLP2PLz4GlobalBytes.Set(float64(b))
+				metrics.HLP2PLz4GlobalPackets.Set(float64(p))
+				metrics.HLP2PLz4GlobalRatio.Set(r)
+				gotGlobal = true
+				continue
+			}
+		}
+		if !gotPeer {
+			if peers, ok := parseLz4PeerLine(line); ok {
+				publishLz4Peers(peers, prev)
+				gotPeer = true
+				continue
+			}
+		}
+	}
+
+	// On the rare edge where the tail contains only one record shape
+	// (day-file rollover, or a torn last write), we leave the other
+	// metric set at its previous values. That's strictly better than
+	// zeroing — a stale-but-recent gauge gives an operator a
+	// degraded-but-useful reading; a zeroed gauge looks like an
+	// incident.
+
+	*lastMtime = info.ModTime()
+}
+
+func publishLz4Peers(peers []lz4PeerSample, prev map[string]map[string]bool) {
+	byDir := map[string][]lz4PeerSample{"in": {}, "out": {}}
+	for _, p := range peers {
+		byDir[p.direction] = append(byDir[p.direction], p)
+	}
+
+	for direction, list := range byDir {
+		sort.Slice(list, func(a, b int) bool { return list[a].bytes > list[b].bytes })
+		current := make(map[string]bool, tcpLz4TopN+1)
+		var otherBytes, otherPackets int64
+		var otherRatioWeight float64 // weighted by bytes
+		var otherRatioBytesSum float64
+
+		for i, p := range list {
+			if i < tcpLz4TopN {
+				metrics.HLP2PLz4BytesTotal.WithLabelValues(p.ip, direction).Set(float64(p.bytes))
+				metrics.HLP2PLz4PacketsTotal.WithLabelValues(p.ip, direction).Set(float64(p.packets))
+				metrics.HLP2PLz4CompressionRatio.WithLabelValues(p.ip, direction).Set(p.ratio)
+				current[p.ip] = true
+			} else {
+				otherBytes += p.bytes
+				otherPackets += p.packets
+				otherRatioWeight += p.ratio * float64(p.bytes)
+				otherRatioBytesSum += float64(p.bytes)
+			}
+		}
+		if otherBytes > 0 {
+			metrics.HLP2PLz4BytesTotal.WithLabelValues("other", direction).Set(float64(otherBytes))
+			metrics.HLP2PLz4PacketsTotal.WithLabelValues("other", direction).Set(float64(otherPackets))
+			if otherRatioBytesSum > 0 {
+				metrics.HLP2PLz4CompressionRatio.WithLabelValues("other", direction).
+					Set(otherRatioWeight / otherRatioBytesSum)
+			}
+			current["other"] = true
+		}
+
+		// Drop labels that fell out of the top-N.
+		for ip := range prev[direction] {
+			if !current[ip] {
+				metrics.HLP2PLz4BytesTotal.DeleteLabelValues(ip, direction)
+				metrics.HLP2PLz4PacketsTotal.DeleteLabelValues(ip, direction)
+				metrics.HLP2PLz4CompressionRatio.DeleteLabelValues(ip, direction)
+				delete(prev[direction], ip)
+			}
+		}
+		for ip := range current {
+			prev[direction][ip] = true
+		}
+	}
+}
+
+// parseLz4PeerLine returns the per-peer samples from a line of the form:
+//
+//	["<iso>", [ [["In"|"Out", "<ip>", <port>], <bytes>, <packets>, <ratio>], ... ]]
+//
+// Returns ok=false if the inner array entries don't all have the
+// 4-element shape (this is what distinguishes a peer line from a global
+// line, since the global line has a 3-element inner with no [dir,ip,port]
+// key).
+func parseLz4PeerLine(line []byte) ([]lz4PeerSample, bool) {
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return nil, false
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(outer[1], &entries); err != nil || len(entries) == 0 {
+		return nil, false
+	}
+	// Sniff the first entry — must be a 4-tuple starting with [dir, ip, port].
+	var first []json.RawMessage
+	if err := json.Unmarshal(entries[0], &first); err != nil || len(first) < 4 {
+		return nil, false
+	}
+	var firstKey [3]json.RawMessage
+	if err := json.Unmarshal(first[0], &firstKey); err != nil {
+		return nil, false
+	}
+
+	out := make([]lz4PeerSample, 0, len(entries))
+	for _, raw := range entries {
+		var entry []json.RawMessage
+		if err := json.Unmarshal(raw, &entry); err != nil || len(entry) < 4 {
+			continue
+		}
+		var key [3]json.RawMessage
+		if err := json.Unmarshal(entry[0], &key); err != nil {
+			continue
+		}
+		var dir, ip string
+		if err := json.Unmarshal(key[0], &dir); err != nil {
+			continue
+		}
+		if err := json.Unmarshal(key[1], &ip); err != nil {
+			continue
+		}
+		var bytesN, packetsN int64
+		if err := json.Unmarshal(entry[1], &bytesN); err != nil {
+			continue
+		}
+		if err := json.Unmarshal(entry[2], &packetsN); err != nil {
+			continue
+		}
+		var ratio float64
+		if err := json.Unmarshal(entry[3], &ratio); err != nil {
+			continue
+		}
+		var direction string
+		switch dir {
+		case "In":
+			direction = "in"
+		case "Out":
+			direction = "out"
+		default:
+			continue
+		}
+		out = append(out, lz4PeerSample{
+			direction: direction,
+			ip:        ip,
+			bytes:     bytesN,
+			packets:   packetsN,
+			ratio:     ratio,
+		})
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// parseLz4GlobalLine handles the aggregate row:
+//
+//	["<iso>", [<bytes>, <packets>, <ratio>]]
+//
+// Returns ok=false on any structural mismatch.
+func parseLz4GlobalLine(line []byte) (int64, int64, float64, bool) {
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return 0, 0, 0, false
+	}
+	var inner []json.RawMessage
+	if err := json.Unmarshal(outer[1], &inner); err != nil || len(inner) != 3 {
+		return 0, 0, 0, false
+	}
+	// Must be 3 numbers; if the first element is itself an array, this is a
+	// peer line, not a global aggregate.
+	var b, p int64
+	if err := json.Unmarshal(inner[0], &b); err != nil {
+		return 0, 0, 0, false
+	}
+	if err := json.Unmarshal(inner[1], &p); err != nil {
+		return 0, 0, 0, false
+	}
+	var r float64
+	if err := json.Unmarshal(inner[2], &r); err != nil {
+		return 0, 0, 0, false
+	}
+	return b, p, r, true
+}

--- a/internal/monitors/tcp_lz4_monitor_test.go
+++ b/internal/monitors/tcp_lz4_monitor_test.go
@@ -1,0 +1,72 @@
+package monitors
+
+import (
+	"testing"
+)
+
+func TestParseLz4PeerLine_RealSample(t *testing.T) {
+	// Trimmed real sample from a live mainnet peer's tcp_lz4_stats file.
+	// Two peers, one Out one In.
+	line := []byte(`["2026-05-25T10:44:59.848700563",[[["Out","37.27.229.79",4001],342919728,4454,0.6510],[["In","52.198.167.169",4001],601888685,4474,0.6208]]]`)
+	peers, ok := parseLz4PeerLine(line)
+	if !ok {
+		t.Fatalf("ok=false on valid sample")
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+	// Order-preserving from input.
+	if peers[0].direction != "out" || peers[0].ip != "37.27.229.79" || peers[0].bytes != 342919728 || peers[0].ratio != 0.6510 {
+		t.Errorf("peer 0 mismatch: %+v", peers[0])
+	}
+	if peers[1].direction != "in" || peers[1].ip != "52.198.167.169" || peers[1].packets != 4474 {
+		t.Errorf("peer 1 mismatch: %+v", peers[1])
+	}
+}
+
+func TestParseLz4PeerLine_RejectsGlobalLine(t *testing.T) {
+	// Global aggregate row — must NOT parse as a peer line.
+	line := []byte(`["2026-05-25T10:44:59.848744913",[5416937682,40265,0.6208]]`)
+	_, ok := parseLz4PeerLine(line)
+	if ok {
+		t.Errorf("global line should not parse as peer line")
+	}
+}
+
+func TestParseLz4GlobalLine_RealSample(t *testing.T) {
+	line := []byte(`["2026-05-25T10:44:59.848744913",[5416937682,40265,0.6208]]`)
+	b, p, r, ok := parseLz4GlobalLine(line)
+	if !ok {
+		t.Fatalf("ok=false")
+	}
+	if b != 5416937682 || p != 40265 || r != 0.6208 {
+		t.Errorf("got bytes=%d packets=%d ratio=%v", b, p, r)
+	}
+}
+
+func TestParseLz4GlobalLine_RejectsPeerLine(t *testing.T) {
+	// Peer line — outer inner is a 2-element array, not 3 numbers.
+	line := []byte(`["2026-05-25T10:44:59.848700563",[[["Out","1.2.3.4",4001],1,1,0.5]]]`)
+	_, _, _, ok := parseLz4GlobalLine(line)
+	if ok {
+		t.Errorf("peer line should not parse as global line")
+	}
+}
+
+func TestParseLz4Lines_Malformed(t *testing.T) {
+	for _, line := range [][]byte{
+		[]byte(``),
+		[]byte(`not json`),
+		[]byte(`{}`),
+		[]byte(`[1]`),
+		[]byte(`["ts", []]`),
+		[]byte(`["ts", "x"]`),
+	} {
+		if _, ok := parseLz4PeerLine(line); ok {
+			t.Errorf("peer parser should reject %q", line)
+		}
+		if _, _, _, ok := parseLz4GlobalLine(line); ok {
+			t.Errorf("global parser should reject %q", line)
+		}
+	}
+}

--- a/internal/monitors/tcp_traffic_monitor.go
+++ b/internal/monitors/tcp_traffic_monitor.go
@@ -1,0 +1,251 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// tcpTrafficPollInterval matches the node's own ~30s sample cadence. There
+// is no value in polling faster than the file changes.
+const tcpTrafficPollInterval = 30 * time.Second
+
+// tcpTrafficTopN bounds the published per-IP cardinality per direction.
+// Everything below the cutoff is rolled into a single ip="other" bucket.
+// 16 keeps the dashboard readable while still surfacing the top inbound
+// + outbound peers that operators actually care about.
+const tcpTrafficTopN = 16
+
+// peerSample is one (direction, ip) → throughput row from the latest
+// tcp_traffic line.
+type peerSample struct {
+	dir   string // "in" or "out"
+	ip    string
+	value float64
+}
+
+// LatestTCPTrafficSample exposes the most recent parsed tcp_traffic sample
+// to other monitors (specifically parent_peer_monitor) so they don't each
+// re-parse the file. The whole struct is replaced atomically under mu so
+// readers get a consistent (ts, inbound, outbound) triple.
+type LatestTCPTrafficSample struct {
+	mu        sync.Mutex
+	timestamp time.Time
+	inbound   []peerSample // sorted desc by value
+	outbound  []peerSample // sorted desc by value
+}
+
+var sharedTCPTraffic LatestTCPTrafficSample
+
+// LatestTCPTrafficSnapshot returns the most recent tcp_traffic sample plus
+// its source timestamp. Empty slices and a zero time are returned when no
+// sample has been read yet. The returned slices alias the monitor's
+// internal state; treat them as read-only.
+func LatestTCPTrafficSnapshot() (ts time.Time, in []peerSample, out []peerSample) {
+	sharedTCPTraffic.mu.Lock()
+	defer sharedTCPTraffic.mu.Unlock()
+	return sharedTCPTraffic.timestamp, sharedTCPTraffic.inbound, sharedTCPTraffic.outbound
+}
+
+// StartTCPTrafficMonitor watches $NODE_HOME/data/tcp_traffic/hourly. Each
+// line of the latest hour-file is a snapshot of per-peer throughput. We
+// only consume the last line per tick.
+func StartTCPTrafficMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "tcp_traffic", "hourly")
+
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("tcp_traffic",
+			"tcp_traffic directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("tcp_traffic", "watching %s", root)
+
+	ticker := time.NewTicker(tcpTrafficPollInterval)
+	defer ticker.Stop()
+
+	// Track which IPs are currently in the gauge vec per direction so we
+	// can Delete() series when an IP drops out of the top-N. Without this
+	// the per-IP cardinality would creep upward over time.
+	prevPublished := map[string]map[string]bool{
+		"in":  {},
+		"out": {},
+	}
+
+	tickTCPTraffic(root, prevPublished)
+	metrics.MarkMonitorTick("tcp_traffic")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickTCPTraffic(root, prevPublished)
+			metrics.MarkMonitorTick("tcp_traffic")
+		}
+	}
+}
+
+func tickTCPTraffic(root string, prevPublished map[string]map[string]bool) {
+	filePath, err := latestHourlyFile(root)
+	if err != nil {
+		return
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return
+	}
+	line, ok := lastFullLine(data)
+	if !ok {
+		return
+	}
+	sampleTime, in, out, ok := parseTCPTrafficLine(line)
+	if !ok {
+		return
+	}
+
+	sort.Slice(in, func(a, b int) bool { return in[a].value > in[b].value })
+	sort.Slice(out, func(a, b int) bool { return out[a].value > out[b].value })
+
+	sharedTCPTraffic.mu.Lock()
+	sharedTCPTraffic.timestamp = sampleTime
+	sharedTCPTraffic.inbound = in
+	sharedTCPTraffic.outbound = out
+	sharedTCPTraffic.mu.Unlock()
+
+	publishTCPDirection("in", in, prevPublished["in"])
+	publishTCPDirection("out", out, prevPublished["out"])
+
+	if !sampleTime.IsZero() {
+		metrics.HLP2PSampleAgeSeconds.Set(time.Since(sampleTime).Seconds())
+	}
+}
+
+func publishTCPDirection(direction string, samples []peerSample, prev map[string]bool) {
+	current := make(map[string]bool, tcpTrafficTopN+1)
+
+	var topSum, otherSum float64
+	for i, s := range samples {
+		if i < tcpTrafficTopN {
+			metrics.HLP2PPeerTraffic.WithLabelValues(s.ip, direction).Set(s.value)
+			current[s.ip] = true
+			topSum += s.value
+		} else {
+			otherSum += s.value
+		}
+	}
+	if otherSum > 0 {
+		metrics.HLP2PPeerTraffic.WithLabelValues("other", direction).Set(otherSum)
+		current["other"] = true
+	}
+
+	// Drop series for IPs that are no longer in the top-N.
+	for ip := range prev {
+		if !current[ip] {
+			metrics.HLP2PPeerTraffic.DeleteLabelValues(ip, direction)
+			delete(prev, ip)
+		}
+	}
+	for ip := range current {
+		prev[ip] = true
+	}
+
+	metrics.HLP2PTotalTraffic.WithLabelValues(direction).Set(topSum + otherSum)
+	metrics.HLP2PPeerCount.WithLabelValues(direction).Set(float64(len(samples)))
+}
+
+// parseTCPTrafficLine consumes one record of the form
+//
+//	["<iso>", [[["In"|"Out", "<ip>", <port>], <bytes>], ...]]
+//
+// Returns inbound and outbound slices separately. Returns ok=false on any
+// structural mismatch.
+func parseTCPTrafficLine(line []byte) (time.Time, []peerSample, []peerSample, bool) {
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return time.Time{}, nil, nil, false
+	}
+	var tsStr string
+	if err := json.Unmarshal(outer[0], &tsStr); err != nil {
+		return time.Time{}, nil, nil, false
+	}
+	ts, _ := parseVisorTime(tsStr)
+
+	var flows []json.RawMessage
+	if err := json.Unmarshal(outer[1], &flows); err != nil {
+		return ts, nil, nil, false
+	}
+
+	// Sum values per (direction, ip). The hl-node tcp_traffic file is
+	// keyed by (direction, ip, port), so a single peer that holds both
+	// the 4001 and 4002 connections shows up as two rows. For the
+	// purposes of "which peer is delivering the most data" we want one
+	// row per IP-direction.
+	inAcc := map[string]float64{}
+	outAcc := map[string]float64{}
+	for _, flow := range flows {
+		var pair [2]json.RawMessage
+		if err := json.Unmarshal(flow, &pair); err != nil {
+			continue
+		}
+		var key [3]json.RawMessage
+		if err := json.Unmarshal(pair[0], &key); err != nil {
+			continue
+		}
+		var dirStr, ip string
+		if err := json.Unmarshal(key[0], &dirStr); err != nil {
+			continue
+		}
+		if err := json.Unmarshal(key[1], &ip); err != nil {
+			continue
+		}
+		var value float64
+		if err := json.Unmarshal(pair[1], &value); err != nil {
+			continue
+		}
+		switch dirStr {
+		case "In":
+			inAcc[ip] += value
+		case "Out":
+			outAcc[ip] += value
+		}
+	}
+
+	in := make([]peerSample, 0, len(inAcc))
+	for ip, v := range inAcc {
+		in = append(in, peerSample{dir: "in", ip: ip, value: v})
+	}
+	out := make([]peerSample, 0, len(outAcc))
+	for ip, v := range outAcc {
+		out = append(out, peerSample{dir: "out", ip: ip, value: v})
+	}
+	return ts, in, out, true
+}
+
+// lastFullLine returns the last complete newline-terminated record in
+// data, scanning backwards over any torn trailing write.
+func lastFullLine(data []byte) ([]byte, bool) {
+	end := len(data)
+	for end > 0 && data[end-1] == '\n' {
+		end--
+	}
+	if end == 0 {
+		return nil, false
+	}
+	start := bytes.LastIndexByte(data[:end], '\n') + 1
+	line := bytes.TrimSpace(data[start:end])
+	if len(line) == 0 {
+		return nil, false
+	}
+	return line, true
+}

--- a/internal/monitors/tcp_traffic_monitor_test.go
+++ b/internal/monitors/tcp_traffic_monitor_test.go
@@ -1,0 +1,118 @@
+package monitors
+
+import (
+	"testing"
+)
+
+func TestParseTCPTrafficLine_RealSample(t *testing.T) {
+	// Real sample line lifted from a live mainnet peer's
+	// data/tcp_traffic/hourly/<date>/<hour>. Three flows: one In, two Out.
+	line := []byte(`["2026-05-25T10:37:08.672768629",[[["In","52.198.167.169",4001],0.8248638739917559],[["Out","162.19.103.75",4001],0.8252117484278043],[["Out","79.137.101.77",4001],0.8252116450033067]]]`)
+
+	ts, in, out, ok := parseTCPTrafficLine(line)
+	if !ok {
+		t.Fatalf("parse returned ok=false on valid sample")
+	}
+	if ts.IsZero() {
+		t.Errorf("expected non-zero timestamp")
+	}
+	if len(in) != 1 {
+		t.Fatalf("expected 1 inbound flow, got %d", len(in))
+	}
+	if in[0].ip != "52.198.167.169" || in[0].value != 0.8248638739917559 {
+		t.Errorf("inbound mismatch: %+v", in[0])
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 outbound flows, got %d", len(out))
+	}
+	// Outbound IPs are inserted via a map walk so order is non-deterministic;
+	// assert presence by sum.
+	outIPs := map[string]float64{}
+	for _, p := range out {
+		outIPs[p.ip] = p.value
+	}
+	if outIPs["162.19.103.75"] == 0 || outIPs["79.137.101.77"] == 0 {
+		t.Errorf("missing expected outbound IP in %+v", out)
+	}
+}
+
+func TestParseTCPTrafficLine_Malformed(t *testing.T) {
+	cases := [][]byte{
+		[]byte(``),
+		[]byte(`not json`),
+		[]byte(`{}`),
+		[]byte(`[1,2,3]`),                            // wrong outer arity
+		[]byte(`["2026-01-01T00:00:00", "garbage"]`), // inner not array
+	}
+	for i, line := range cases {
+		_, _, _, ok := parseTCPTrafficLine(line)
+		if ok {
+			t.Errorf("case %d: expected ok=false on malformed input %q", i, line)
+		}
+	}
+}
+
+func TestParseTCPTrafficLine_DedupesSameIPDifferentPorts(t *testing.T) {
+	// One peer IP, two ports (4001 + 4002). Must collapse into a
+	// single inbound row with summed bytes, otherwise parent_peer ends
+	// up logging "ambiguous parent peer: top=X runner-up=X".
+	line := []byte(`["2026-05-25T10:00:00",[[["In","1.1.1.1",4001],0.4],[["In","1.1.1.1",4002],0.6]]]`)
+	_, in, _, ok := parseTCPTrafficLine(line)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if len(in) != 1 {
+		t.Fatalf("expected 1 deduped inbound row, got %d (%+v)", len(in), in)
+	}
+	const want = 1.0
+	if got := in[0].value; got < want-1e-9 || got > want+1e-9 {
+		t.Errorf("expected summed value %v, got %v", want, got)
+	}
+	if in[0].ip != "1.1.1.1" {
+		t.Errorf("ip = %q", in[0].ip)
+	}
+}
+
+func TestParseTCPTrafficLine_SkipsBadFlows(t *testing.T) {
+	// Two valid flows and one with a corrupted inner key shape; expect the
+	// good flows to land and the bad one to be silently skipped.
+	line := []byte(`["2026-05-25T10:00:00",[[["In","1.1.1.1",4001],0.5],"junk",[["Out","2.2.2.2",4001],1.5]]]`)
+	_, in, out, ok := parseTCPTrafficLine(line)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if len(in) != 1 || in[0].ip != "1.1.1.1" {
+		t.Errorf("in: %+v", in)
+	}
+	if len(out) != 1 || out[0].ip != "2.2.2.2" {
+		t.Errorf("out: %+v", out)
+	}
+}
+
+func TestLastFullLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantOK  bool
+	}{
+		{"trailing newline", "a\nb\nc\n", "c", true},
+		{"no trailing newline", "a\nb\nc", "c", true},
+		{"single line no newline", "alone", "alone", true},
+		{"empty", "", "", false},
+		{"only newlines", "\n\n\n", "", false},
+		{"torn last", "good\nbad", "bad", true},
+		{"trailing whitespace", "x\n   \n", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := lastFullLine([]byte(c.input))
+			if ok != c.wantOK {
+				t.Fatalf("ok=%v want %v (input %q)", ok, c.wantOK, c.input)
+			}
+			if string(got) != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/monitors/tmp_dir_monitor.go
+++ b/internal/monitors/tmp_dir_monitor.go
@@ -1,0 +1,84 @@
+package monitors
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const (
+	tmpDirPollInterval = 5 * time.Minute
+	tmpDirStaleAge     = 24 * time.Hour
+)
+
+// StartTmpDirMonitor walks $NODE_HOME/tmp once every 5 minutes and
+// publishes two gauges: total byte size and a count of files older than
+// 24h. The latter catches orphaned writes from past crashes — on the
+// test peer we observed ~2.5 GB of stale tmp files dating to May/Jul
+// 2025, which is what an alert would have caught.
+func StartTmpDirMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "tmp")
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("tmp_dir",
+			"$NODE_HOME/tmp not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("tmp_dir", "watching %s every %s", root, tmpDirPollInterval)
+
+	ticker := time.NewTicker(tmpDirPollInterval)
+	defer ticker.Stop()
+
+	tickTmpDir(root)
+	metrics.MarkMonitorTick("tmp_dir")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickTmpDir(root)
+			metrics.MarkMonitorTick("tmp_dir")
+		}
+	}
+}
+
+func tickTmpDir(root string) {
+	var total int64
+	var stale int64
+	var shellExec int64
+	threshold := time.Now().Add(-tmpDirStaleAge)
+	shellExecDir := filepath.Join(root, "shell_rs_out")
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		if info.ModTime().Before(threshold) {
+			stale++
+		}
+		// Sub-bucket: count files under tmp/shell_rs_out/ separately.
+		// Each visor shell-exec drops a (usually empty) file here; a
+		// healthy node should keep this count low. Sustained growth
+		// means the visor's cleanup pass is broken.
+		if strings.HasPrefix(path, shellExecDir+string(filepath.Separator)) || path == shellExecDir {
+			shellExec++
+		}
+		return nil
+	})
+	metrics.HLNodeTmpBytes.Set(float64(total))
+	metrics.HLNodeTmpStaleFiles.Set(float64(stale))
+	metrics.HLNodeShellExecPending.Set(float64(shellExec))
+}

--- a/internal/monitors/tokio_runtime_monitor.go
+++ b/internal/monitors/tokio_runtime_monitor.go
@@ -1,0 +1,153 @@
+package monitors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+const tokioRuntimePollInterval = 60 * time.Second
+
+// tokioTaskAllowlist bounds label cardinality. On a live mainnet peer the
+// file contains exactly 12 task names; any new task that appears in the
+// future will land in this allowlist after a code review (with the same
+// cardinality discipline as subsystem_latency_monitor).
+var tokioTaskAllowlist = map[string]bool{
+	"gossip rpc request handler":         true,
+	"gossip rpc status":                  true,
+	"tokio_scheduled_observer_fast":      true,
+	"tokio_scheduled_observer_slow":      true,
+	"traffic_logger":                     true,
+	"lz4_stats":                          true,
+	"nv_stream_forward_client_blocks":    true,
+	"nv_stream_apply_execution_state":    true,
+	"gossip connection listener":         true,
+	"validator connection listener":      true,
+	"node_disabler":                      true,
+	"node_evm_request_handler":           true,
+}
+
+// tokioTaskSample mirrors one record of the JSON-lines file.
+type tokioTaskSample struct {
+	TaskName               string  `json:"task_name"`
+	InstrumentedCount      int64   `json:"instrumented_count"`
+	DroppedCount           int64   `json:"dropped_count"`
+	TotalIdleDuration      float64 `json:"total_idle_duration"`
+	TotalScheduledCount    int64   `json:"total_scheduled_count"`
+	TotalScheduledDuration float64 `json:"total_scheduled_duration"`
+	TotalPollCount         int64   `json:"total_poll_count"`
+	TotalPollDuration      float64 `json:"total_poll_duration"`
+	TotalFastPollCount     int64   `json:"total_fast_poll_count"`
+	TotalSlowPollCount     int64   `json:"total_slow_poll_count"`
+	TotalShortDelayCount   int64   `json:"total_short_delay_count"`
+	TotalLongDelayCount    int64   `json:"total_long_delay_count"`
+}
+
+// StartTokioRuntimeMonitor watches
+// $NODE_HOME/data/tokio_spawn_forever_metrics/hourly/<date>/<hour>.
+//
+// On each tick: read the tail of the latest hour-file, decode the last
+// JSON-line record per allowlisted task name, publish the cumulative
+// counters. Modeled as gauges (not Prometheus counters) because the
+// node's "total_*" values reset on process restart, and a counter
+// regression would confuse rate() queries.
+//
+// Operator signal: total_slow_poll_count and total_long_delay_count
+// climbing fast = the async runtime is starved or a task is doing
+// CPU-heavy work in poll(). dropped_count > 0 = task panicked.
+func StartTokioRuntimeMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	root := filepath.Join(cfg.NodeHome, "data", "tokio_spawn_forever_metrics", "hourly")
+	if _, err := os.Stat(root); err != nil {
+		logger.InfoComponent("tokio_runtime",
+			"tokio_spawn_forever_metrics directory not present (%s); monitor idle", root)
+		<-ctx.Done()
+		return
+	}
+
+	logger.InfoComponent("tokio_runtime", "watching %s", root)
+
+	ticker := time.NewTicker(tokioRuntimePollInterval)
+	defer ticker.Stop()
+
+	tickTokio(root)
+	metrics.MarkMonitorTick("tokio_runtime")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickTokio(root)
+			metrics.MarkMonitorTick("tokio_runtime")
+		}
+	}
+}
+
+func tickTokio(root string) {
+	path, err := latestHourlyFile(root)
+	if err != nil {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	// Walk lines backwards, keeping the FIRST sample we see for each
+	// allowlisted task name. Stop once we have every allowed name OR
+	// run out of file.
+	seen := map[string]bool{}
+	want := len(tokioTaskAllowlist)
+	end := len(data)
+	for end > 0 && len(seen) < want {
+		for end > 0 && data[end-1] == '\n' {
+			end--
+		}
+		if end == 0 {
+			break
+		}
+		start := bytes.LastIndexByte(data[:end], '\n') + 1
+		line := bytes.TrimSpace(data[start:end])
+		end = start - 1
+		if len(line) == 0 || line[0] != '[' {
+			continue
+		}
+		s, ok := parseTokioLine(line)
+		if !ok || !tokioTaskAllowlist[s.TaskName] || seen[s.TaskName] {
+			continue
+		}
+		publishTokioSample(s)
+		seen[s.TaskName] = true
+	}
+}
+
+func parseTokioLine(line []byte) (tokioTaskSample, bool) {
+	var outer [2]json.RawMessage
+	if err := json.Unmarshal(line, &outer); err != nil {
+		return tokioTaskSample{}, false
+	}
+	var s tokioTaskSample
+	if err := json.Unmarshal(outer[1], &s); err != nil {
+		return tokioTaskSample{}, false
+	}
+	if s.TaskName == "" {
+		return tokioTaskSample{}, false
+	}
+	return s, true
+}
+
+func publishTokioSample(s tokioTaskSample) {
+	metrics.HLTokioTaskPollSecondsTotal.WithLabelValues(s.TaskName).Set(s.TotalPollDuration)
+	metrics.HLTokioTaskPollsTotal.WithLabelValues(s.TaskName).Set(float64(s.TotalPollCount))
+	metrics.HLTokioTaskSlowPollsTotal.WithLabelValues(s.TaskName).Set(float64(s.TotalSlowPollCount))
+	metrics.HLTokioTaskLongDelaysTotal.WithLabelValues(s.TaskName).Set(float64(s.TotalLongDelayCount))
+	metrics.HLTokioTaskIdleSecondsTotal.WithLabelValues(s.TaskName).Set(s.TotalIdleDuration)
+	metrics.HLTokioTaskDroppedTotal.WithLabelValues(s.TaskName).Set(float64(s.DroppedCount))
+}

--- a/internal/monitors/tokio_runtime_monitor_test.go
+++ b/internal/monitors/tokio_runtime_monitor_test.go
@@ -1,0 +1,36 @@
+package monitors
+
+import (
+	"testing"
+)
+
+func TestParseTokioLine_RealSample(t *testing.T) {
+	line := []byte(`["2026-05-25T06:59:59.712513828",{"task_name":"gossip rpc request handler","instrumented_count":0,"dropped_count":0,"first_poll_count":0,"total_first_poll_delay":0.0,"total_idled_count":5,"total_idle_duration":53.476108197,"total_scheduled_count":5,"total_scheduled_duration":0.0000577,"total_poll_count":5,"total_poll_duration":0.00048247,"total_fast_poll_count":5,"total_slow_poll_count":0,"total_short_delay_count":5,"total_long_delay_count":0}]`)
+	s, ok := parseTokioLine(line)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if s.TaskName != "gossip rpc request handler" {
+		t.Errorf("task_name = %q", s.TaskName)
+	}
+	if s.TotalPollCount != 5 || s.TotalSlowPollCount != 0 || s.TotalLongDelayCount != 0 {
+		t.Errorf("counts: %+v", s)
+	}
+	if s.TotalPollDuration != 0.00048247 {
+		t.Errorf("poll_duration = %v", s.TotalPollDuration)
+	}
+}
+
+func TestParseTokioLine_Malformed(t *testing.T) {
+	for _, line := range [][]byte{
+		[]byte(``),
+		[]byte(`["ts"]`),                         // missing inner
+		[]byte(`["ts", null]`),                   // inner not object
+		[]byte(`["ts", {"task_name": ""}]`),      // empty task_name
+		[]byte(`["ts", {"no_task_name": true}]`), // missing field
+	} {
+		if _, ok := parseTokioLine(line); ok {
+			t.Errorf("should reject %q", line)
+		}
+	}
+}

--- a/internal/monitors/update_checker.go
+++ b/internal/monitors/update_checker.go
@@ -25,7 +25,7 @@ var (
 )
 
 func StartUpdateChecker(ctx context.Context, cfg config.Config, errCh chan<- error) {
-	go func() {
+	goSafe("update_checker", func() {
 		// wait a bit for version monitor to run first
 		time.Sleep(2 * time.Second)
 
@@ -47,7 +47,7 @@ func StartUpdateChecker(ctx context.Context, cfg config.Config, errCh chan<- err
 				}
 			}
 		}
-	}()
+	})
 }
 
 func checkSoftwareUpdate(ctx context.Context, cfg config.Config) error {

--- a/internal/monitors/validator_api_monitor.go
+++ b/internal/monitors/validator_api_monitor.go
@@ -17,7 +17,7 @@ func StartValidatorMonitor(ctx context.Context, cfg config.Config, errCh chan<- 
 	// init HL resolver
 	hlResolver = hyperliquidapi.NewResolver(cfg.Chain)
 
-	go func() {
+	goSafe("validator_api", func() {
 		// run immediately on startup to populate mappings
 		if err := updateValidatorMetrics(ctx, cfg); err != nil {
 			logger.Error("Initial validator monitor update error: %v", err)
@@ -38,7 +38,7 @@ func StartValidatorMonitor(ctx context.Context, cfg config.Config, errCh chan<- 
 				}
 			}
 		}
-	}()
+	})
 }
 
 func updateValidatorMetrics(ctx context.Context, cfg config.Config) error {
@@ -105,6 +105,7 @@ func updateValidatorMetrics(ctx context.Context, cfg config.Config) error {
 	metrics.SetInactiveStake(inactiveStake)
 	metrics.SetValidatorCount(int64(len(summaries)))
 
+	metrics.MarkMonitorTick("validator_api")
 	return nil
 }
 

--- a/internal/monitors/validator_ip_monitor.go
+++ b/internal/monitors/validator_ip_monitor.go
@@ -60,7 +60,7 @@ func StartValidatorIPMonitor(ctx context.Context, cfg config.Config, errCh chan<
 	// create ABCI reader with 8MB buffer
 	reader := abci.NewReader(8)
 
-	go func() {
+	goSafe("validator_ip", func() {
 		stateDir := filepath.Join(cfg.NodeHome, "data/periodic_abci_states")
 
 		// add directory check
@@ -74,7 +74,7 @@ func StartValidatorIPMonitor(ctx context.Context, cfg config.Config, errCh chan<
 		var lastAttempt time.Time
 
 		// start the ping monitoring in a separate goroutine
-		go monitorValidatorRTT(ctx, errCh)
+		goSafe("validator_ip", func() { monitorValidatorRTT(ctx, errCh) })
 
 		// initial attempt
 		if err := processLatestState(ctx, stateDir, &currentFile, reader); err != nil {
@@ -103,7 +103,7 @@ func StartValidatorIPMonitor(ctx context.Context, cfg config.Config, errCh chan<
 				lastAttempt = time.Now()
 			}
 		}
-	}()
+	})
 }
 
 func processLatestState(ctx context.Context, stateDir string, currentFile *string, reader *abci.Reader) error {

--- a/internal/monitors/validator_latency_monitor.go
+++ b/internal/monitors/validator_latency_monitor.go
@@ -64,8 +64,8 @@ func StartValidatorLatencyMonitor(ctx context.Context, cfg *config.Config, errCh
 	logger.InfoComponent("latency", "Starting validator latency monitor")
 
 	// start monitoring goroutines
-	go m.monitorLatencies(ctx, errCh)
-	go m.monitorEMA(ctx, errCh)
+	goSafe("validator_latency", func() { m.monitorLatencies(ctx, errCh) })
+	goSafe("validator_latency", func() { m.monitorEMA(ctx, errCh) })
 }
 
 // monitors individual validator latency files

--- a/internal/monitors/validator_status_monitor.go
+++ b/internal/monitors/validator_status_monitor.go
@@ -32,7 +32,7 @@ var (
 )
 
 func StartValidatorStatusMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
-	go func() {
+	goSafe("validator_status", func() {
 		// initial status check to set up logging context
 		statusDir := filepath.Join(cfg.NodeHome, "data/node_logs/status/hourly")
 		if _, err := os.Stat(statusDir); os.IsNotExist(err) {
@@ -56,7 +56,7 @@ func StartValidatorStatusMonitor(ctx context.Context, cfg config.Config, errCh c
 				}
 			}
 		}
-	}()
+	})
 }
 
 func readValidatorStatus(nodeHome string) error {

--- a/internal/monitors/version_monitor.go
+++ b/internal/monitors/version_monitor.go
@@ -17,8 +17,26 @@ import (
 
 var currentCommitHash string
 
+// NodeBinaryReady reports whether the configured hl-node binary is present
+// and looks executable. The exporter calls this at startup to decide
+// whether to launch the version monitor; if the binary isn't there we
+// no-op rather than spam errors every 30 minutes. Returns nil if ready.
+func NodeBinaryReady(cfg config.Config) (string, error) {
+	info, err := os.Stat(cfg.NodeBinary)
+	if err != nil {
+		return cfg.NodeBinary, fmt.Errorf("hl-node binary not found at %s: %w", cfg.NodeBinary, err)
+	}
+	if info.IsDir() {
+		return cfg.NodeBinary, fmt.Errorf("hl-node path is a directory: %s", cfg.NodeBinary)
+	}
+	if info.Mode()&0111 == 0 {
+		return cfg.NodeBinary, fmt.Errorf("hl-node at %s is not executable", cfg.NodeBinary)
+	}
+	return cfg.NodeBinary, nil
+}
+
 func StartVersionMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
-	go func() {
+	goSafe("version", func() {
 		// run immediately on startup
 		if err := updateVersionInfo(ctx, cfg); err != nil {
 			errCh <- fmt.Errorf("version monitor error: %w", err)
@@ -37,7 +55,7 @@ func StartVersionMonitor(ctx context.Context, cfg config.Config, errCh chan<- er
 				}
 			}
 		}
-	}()
+	})
 }
 
 func updateVersionInfo(ctx context.Context, cfg config.Config) error {

--- a/internal/monitors/visor_monitor.go
+++ b/internal/monitors/visor_monitor.go
@@ -1,0 +1,227 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/validaoxyz/hyperliquid-exporter/internal/config"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/logger"
+	"github.com/validaoxyz/hyperliquid-exporter/internal/metrics"
+)
+
+// visorState mirrors the JSON record the visor writes to disk. The schema
+// has been stable across hl-node releases since Aug 2025; we tolerate extra
+// fields and missing fields gracefully.
+type visorState struct {
+	InitialHeight          int64   `json:"initial_height"`
+	Height                 int64   `json:"height"`
+	ScheduledFreezeHeight  *int64  `json:"scheduled_freeze_height"`
+	ConsensusTime          string  `json:"consensus_time"`
+	WallClockTime          string  `json:"wall_clock_time"`
+	ReferenceLagSeconds    *float64 `json:"reference_lag_seconds,omitempty"`
+	ReferenceLag           *float64 `json:"reference_lag,omitempty"`
+}
+
+const visorPollInterval = 10 * time.Second
+
+// StartVisorMonitor watches the visor sync state. Two sources, both
+// updated by hl-visor:
+//
+//   - $NODE_HOME/hyperliquid_data/visor_abci_state.json: pretty-printed
+//     JSON snapshot, kept current. Cheap to stat and re-read.
+//   - $NODE_HOME/data/visor_abci_states/hourly/<YYYYMMDD>/<H>: rolling
+//     JSON-line log. Used as a fallback if the live snapshot is missing.
+//
+// Exposes hl_visor_height and the lag/skew metrics. This is the
+// most important sync-health signal for a Hyperliquid node operator.
+func StartVisorMonitor(ctx context.Context, cfg config.Config, errCh chan<- error) {
+	snapshotPath := filepath.Join(cfg.NodeHome, "hyperliquid_data", "visor_abci_state.json")
+	historicalDir := filepath.Join(cfg.NodeHome, "data", "visor_abci_states", "hourly")
+
+	logger.InfoComponent("visor", "starting visor state monitor: snapshot=%s historical=%s",
+		snapshotPath, historicalDir)
+
+	ticker := time.NewTicker(visorPollInterval)
+	defer ticker.Stop()
+
+	// Run once immediately so the first scrape isn't empty.
+	tickVisor(snapshotPath, historicalDir, errCh)
+	metrics.MarkMonitorTick("visor")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickVisor(snapshotPath, historicalDir, errCh)
+			metrics.MarkMonitorTick("visor")
+		}
+	}
+}
+
+func tickVisor(snapshotPath, historicalDir string, errCh chan<- error) {
+	state, ts, err := readLatestVisorState(snapshotPath, historicalDir)
+	if err != nil {
+		// Don't flood errCh on a fresh / mid-restart node — debug-log and
+		// move on. The exporter health gauges will reflect the missing tick.
+		logger.DebugComponent("visor", "no visor state yet: %v", err)
+		return
+	}
+	publishVisorState(state, ts)
+}
+
+func readLatestVisorState(snapshotPath, historicalDir string) (visorState, time.Time, error) {
+	// Prefer the live JSON snapshot: it's always the most recent.
+	if data, err := os.ReadFile(snapshotPath); err == nil {
+		var s visorState
+		if jerr := json.Unmarshal(data, &s); jerr == nil && s.Height > 0 {
+			// Sample timestamp comes from the JSON's wall_clock_time
+			// field — the visor writes it at the moment it records the
+			// sample. File mtime would be subject to write-buffering
+			// latency. Fall back to mtime then now() if wall_clock_time
+			// is missing or unparseable.
+			if t, ok := parseVisorTime(s.WallClockTime); ok {
+				return s, t, nil
+			}
+			info, _ := os.Stat(snapshotPath)
+			if info != nil {
+				return s, info.ModTime(), nil
+			}
+			return s, time.Now(), nil
+		}
+	}
+
+	// Fallback: tail the latest hourly file. Format per line:
+	//   ["<iso>", {<state>}]
+	latest, err := latestHourlyFile(historicalDir)
+	if err != nil {
+		return visorState{}, time.Time{}, err
+	}
+	data, err := os.ReadFile(latest)
+	if err != nil {
+		return visorState{}, time.Time{}, err
+	}
+	// take the last newline-terminated record
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i] == '\n' && i+1 < len(data) {
+			data = data[i+1:]
+			break
+		}
+		if i == 1 {
+			break
+		}
+	}
+	var record [2]json.RawMessage
+	if err := json.Unmarshal(data, &record); err != nil {
+		return visorState{}, time.Time{}, fmt.Errorf("decode record: %w", err)
+	}
+	var tsStr string
+	if err := json.Unmarshal(record[0], &tsStr); err != nil {
+		return visorState{}, time.Time{}, fmt.Errorf("decode ts: %w", err)
+	}
+	var s visorState
+	if err := json.Unmarshal(record[1], &s); err != nil {
+		return visorState{}, time.Time{}, fmt.Errorf("decode state: %w", err)
+	}
+	ts, _ := parseVisorTime(tsStr)
+	return s, ts, nil
+}
+
+func publishVisorState(s visorState, sampleTime time.Time) {
+	metrics.HLVisorHeight.Set(float64(s.Height))
+	metrics.HLVisorInitialHeight.Set(float64(s.InitialHeight))
+	// Surface the latest height to node_state_monitor so it can derive
+	// hl_visor_blocks_above_freeze without re-reading the JSON.
+	SetLatestVisorHeight(s.Height)
+	if s.Height > 0 && s.InitialHeight > 0 {
+		metrics.HLVisorBlocksApplied.Set(float64(s.Height - s.InitialHeight))
+	}
+	if s.ScheduledFreezeHeight != nil {
+		metrics.HLVisorScheduledFreezeHeight.Set(float64(*s.ScheduledFreezeHeight))
+	} else {
+		metrics.HLVisorScheduledFreezeHeight.Set(0)
+	}
+
+	consensusT, okC := parseVisorTime(s.ConsensusTime)
+	wallT, okW := parseVisorTime(s.WallClockTime)
+	if okC && okW {
+		metrics.HLVisorConsensusAheadOfWallSeconds.Set(consensusT.Sub(wallT).Seconds())
+	}
+
+	switch {
+	case s.ReferenceLagSeconds != nil:
+		metrics.HLVisorReferenceLagSeconds.Set(*s.ReferenceLagSeconds)
+	case s.ReferenceLag != nil:
+		metrics.HLVisorReferenceLagSeconds.Set(*s.ReferenceLag)
+	}
+
+	if !sampleTime.IsZero() {
+		metrics.HLVisorLastObservationAge.Set(time.Since(sampleTime).Seconds())
+	}
+}
+
+// parseVisorTime accepts the few timestamp shapes hl-visor uses (RFC3339Nano,
+// fractional-second RFC3339, plain ISO without zone). Returns ok=false if
+// none parse.
+func parseVisorTime(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// latestHourlyFile finds the newest file under a .../hourly/<YYYYMMDD>/<H>
+// layout. Date directories are YYYYMMDD-named, so lexicographic order
+// equals chronological order. Hour entries are named "0".."23" with no
+// leading zero, so a naive lex sort would put "10" before "2"; we sort
+// numerically. Falls back to lex if a name is non-numeric.
+func latestHourlyFile(root string) (string, error) {
+	dateDirs, err := os.ReadDir(root)
+	if err != nil {
+		return "", err
+	}
+	dateNames := make([]string, 0, len(dateDirs))
+	for _, e := range dateDirs {
+		if e.IsDir() {
+			dateNames = append(dateNames, e.Name())
+		}
+	}
+	sort.Strings(dateNames)
+	for i := len(dateNames) - 1; i >= 0; i-- {
+		datePath := filepath.Join(root, dateNames[i])
+		hourEntries, err := os.ReadDir(datePath)
+		if err != nil || len(hourEntries) == 0 {
+			continue
+		}
+		hourNames := make([]string, 0, len(hourEntries))
+		for _, e := range hourEntries {
+			hourNames = append(hourNames, e.Name())
+		}
+		sort.Slice(hourNames, func(a, b int) bool {
+			an, aerr := strconv.Atoi(hourNames[a])
+			bn, berr := strconv.Atoi(hourNames[b])
+			if aerr == nil && berr == nil {
+				return an < bn
+			}
+			return hourNames[a] < hourNames[b]
+		})
+		return filepath.Join(datePath, hourNames[len(hourNames)-1]), nil
+	}
+	return "", os.ErrNotExist
+}

--- a/internal/monitors/visor_monitor_test.go
+++ b/internal/monitors/visor_monitor_test.go
@@ -1,0 +1,91 @@
+package monitors
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestLatestHourlyFile_NumericHourSort(t *testing.T) {
+	// Reproduce the bug we found on a live node: hour names are bare
+	// integers ("0".."23") without a leading zero. Lex order would put
+	// "10" before "2", which means a naive sort would pick the wrong
+	// "latest" file when the day crosses 10:00. Verify our sort uses
+	// numeric order.
+	root := t.TempDir()
+	dateDir := filepath.Join(root, "20260525")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create files for hours 1, 2, 9, 10, 11 — lex order would pick 9 last;
+	// numeric order picks 11.
+	for _, h := range []int{1, 2, 9, 10, 11} {
+		path := filepath.Join(dateDir, strconv.Itoa(h))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := latestHourlyFile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSuffix := "/20260525/11"
+	if want := filepath.Join(dateDir, "11"); got != want {
+		t.Errorf("got %q, want %q (suffix %q)", got, want, wantSuffix)
+	}
+}
+
+func TestLatestHourlyFile_LatestDate(t *testing.T) {
+	root := t.TempDir()
+	for _, d := range []string{"20260524", "20260525"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// older date has hour 23, newer date has only hour 6
+		hour := "23"
+		if d == "20260525" {
+			hour = "6"
+		}
+		if err := os.WriteFile(filepath.Join(root, d, hour), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := latestHourlyFile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "20260525", "6")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLatestHourlyFile_MissingRoot(t *testing.T) {
+	_, err := latestHourlyFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error on missing root")
+	}
+}
+
+func TestParseVisorTime(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantOK bool
+	}{
+		{"2026-05-25T07:00:09.501967925", true}, // nanoseconds, no zone
+		{"2026-05-25T07:00:09Z", true},
+		{"2026-05-25T07:00:09.123Z", true},
+		{"2026-05-25T07:00:09", true},
+		{"", false},
+		{"not a time", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			_, ok := parseVisorTime(c.in)
+			if ok != c.wantOK {
+				t.Errorf("ok=%v want %v for %q", ok, c.wantOK, c.in)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This releases hyperliquid-exporter v3 as a backward-compatible superset of v2.0.0.

- Fixes scrape timeout handling, EVM gas-limit classification, monitor panic recovery, consensus monitor map growth, visor observation age, TCP peer deduplication, and Linux process clock documentation.
- Adds exporter self-observability: build info, monitor health, `/livez`, `/readyz`, panic/error counters, and readiness metrics.
- Adds operator-focused monitors for visor state, snapshots, EVM DB checkpoints, subsystem latency, critical messages, TCP traffic, parent peer detection, disk usage, process state, gossip connection events, TCP connection state, and observed node runs.
- Adds opt-in `--probe-info-endpoint`, `--extended-metrics`, container-friendly version/update skip flags, and configurable `--metrics-port`.
- Updates README, CHANGELOG, and UPGRADING docs for v3 rollout.

## Compatibility

Existing v2 metric names, labels, and semantics are preserved. New behavior is either cheap and always-on or behind an opt-in flag. Defaults keep the existing metrics listener port unless `--metrics-port` is set.

## Validation

- `go test ./...`
- `go vet ./...`
- `GOOS=linux GOARCH=amd64 go build -o /tmp/hl-exporter-linux-amd64 ./cmd/hl-exporter`
- `GOOS=darwin GOARCH=arm64 go build -o /tmp/hl-exporter-darwin-arm64 ./cmd/hl-exporter`