### PR TITLE
v4.0.4: keep releases Linux-only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,12 +68,6 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
 
     steps:
       - name: Check out code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,14 +53,11 @@ jobs:
       - name: Build binaries
         run: |
           mkdir -p bin
-          platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
+          platforms=("linux/amd64" "linux/arm64")
           for platform in "${platforms[@]}"; do
             OS=${platform%/*}
             ARCH=${platform#*/}
             OUTPUT_NAME="hl_exporter_${OS}_${ARCH}"
-            if [ "$OS" = "windows" ]; then
-              OUTPUT_NAME+=".exe"
-            fi
             echo "Building $OUTPUT_NAME..."
             GOOS="$OS" GOARCH="$ARCH" CGO_ENABLED=0 go build \
               -trimpath \
@@ -74,11 +71,7 @@ jobs:
           # Keep raw binaries for automated fleet installs and add archives for manual downloads.
           for file in ./*; do
             base=${file#./}
-            if [[ $base == *.exe ]]; then
-              zip "${base%.*}.zip" "$base"
-            else
-              tar -czf "$base.tar.gz" "$base"
-            fi
+            tar -czf "$base.tar.gz" "$base"
           done
           sha256sum ./* > SHA256SUMS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [v4.0.4] - 2026-08-09
 
+### Changed
+
+- Publish Linux amd64 and arm64 release builds only.
+
 ### Fixed
 
 - Accept the current `dropping connection after sending abci state` payload shape while retaining the historical boolean form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.0.4] - 2026-08-09
+
+### Fixed
+
+- Accept the current `dropping connection after sending abci state` payload shape while retaining the historical boolean form.
+
 ## [v4.0.3] - 2026-08-09
 
 ### Changed

--- a/internal/monitors/gossip_connections_monitor.go
+++ b/internal/monitors/gossip_connections_monitor.go
@@ -204,8 +204,13 @@ func validKnownGossipPayload(tag string, inner []json.RawMessage) bool {
 		var endpoint, stream string
 		return unmarshalRequiredJSON(inner[1], &endpoint) == nil && unmarshalRequiredJSON(inner[2], &stream) == nil
 	case "closing gossip stream because no quorum yet", "finished checks", "sending abci_state",
-		"successfully sent abci_state", "dropping connection after sending abci state":
+		"successfully sent abci_state":
 		return validGossipIPFlagPayload(inner, false)
+	case "dropping connection after sending abci state":
+		// Current mainnet can use a short string in the third field while
+		// retained generations use a bool. The payload is validation-only;
+		// neither value becomes a metric label.
+		return validGossipIPBoolOrStringPayload(inner)
 	case "sending evm kvs", "marking node_ip as verified",
 		"closing gossip stream because peer is already connected":
 		// Current mainnet emits these as object-only events while retained
@@ -255,6 +260,18 @@ func validGossipIPFlagPayload(inner []json.RawMessage, allowObjectOnly bool) boo
 	}
 	var flag bool
 	return unmarshalRequiredJSON(inner[2], &flag) == nil
+}
+
+func validGossipIPBoolOrStringPayload(inner []json.RawMessage) bool {
+	if len(inner) != 3 || !rawExactIPObject(inner[1]) {
+		return false
+	}
+	var flag bool
+	if unmarshalRequiredJSON(inner[2], &flag) == nil {
+		return true
+	}
+	var detail string
+	return unmarshalRequiredJSON(inner[2], &detail) == nil && strings.TrimSpace(detail) != ""
 }
 
 func rawExactIPObject(raw json.RawMessage) bool {

--- a/internal/monitors/gossip_connections_monitor_test.go
+++ b/internal/monitors/gossip_connections_monitor_test.go
@@ -56,6 +56,11 @@ func TestParseGossipConnectionLine_KnownEvents(t *testing.T) {
 			"closing_gossip_stream_peer_already_connected",
 		},
 		{
+			"drop after abci current mainnet string detail",
+			`["2026-08-09T06:00:03",["dropping connection after sending abci state",{"Ip":"203.0.113.6"},"closed"]]`,
+			"dropping_connection_after_sending_abci_state",
+		},
+		{
 			"error checking connection historical",
 			`["2026-05-25T06:59:53.6",["error checking connection",{"err":"x"}]]`,
 			"error_checking_connection",
@@ -204,6 +209,10 @@ func TestParseGossipConnectionLine_ExactMatchingAndPayloadShape(t *testing.T) {
 		`["2026-08-09T03:00:03",["closing gossip stream because peer is already connected",{"Ip":"192.0.2.1","extra":true}]]`,
 		`["2026-08-08T03:00:03",["got tcp greeting",{"Ip":"192.0.2.1","extra":true},true]]`,
 		`["2026-08-08T03:00:03",["got tcp greeting",{"Ip":"192.0.2.1"},null]]`,
+		`["2026-08-09T06:00:03",["dropping connection after sending abci state",{"Ip":"192.0.2.1"},""]]`,
+		`["2026-08-09T06:00:03",["dropping connection after sending abci state",{"Ip":"192.0.2.1"},"  "]]`,
+		`["2026-08-09T06:00:03",["dropping connection after sending abci state",{"Ip":"192.0.2.1"},null]]`,
+		`["2026-08-09T06:00:03",["dropping connection after sending abci state",{"Ip":"192.0.2.1"},1]]`,
 		`["2026-08-08T03:00:03",["rejecting gossip stream because max peers reached","limit",{}]]`,
 		`["2026-08-08T03:00:03",["error checking connection","peer",null]]`,
 	} {


### PR DESCRIPTION
Small gossip-log parser compatibility update, plus Linux-only release targets (amd64 and arm64). Metrics and config stay the same.