### PR TITLE
Fix critical projection startup state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.0.5] - 2026-08-09
+
+### Fixed
+
+- Avoid a false critical-message schema error during exporter startup while the paired daily projection is loading.
+
 ## [v4.0.4] - 2026-08-09
 
 ### Changed

--- a/internal/monitors/crit_locations_monitor.go
+++ b/internal/monitors/crit_locations_monitor.go
@@ -116,7 +116,7 @@ func tickCritLocationsAt(path string, state *critLocationsState, now time.Time) 
 		return err
 	}
 	generationChanged := false
-	daily, matched := state.store.withAvailable(source, func(generation critGeneration) bool {
+	daily, dailyAvailable, matched := state.store.withAvailable(source, func(generation critGeneration) bool {
 		if !critRichMatchesDaily(snapshot, info.ModTime(), generation) {
 			return false
 		}
@@ -125,6 +125,17 @@ func tickCritLocationsAt(path string, state *critLocationsState, now time.Time) 
 		state.lastGeneration = generation
 		return true
 	})
+	if !dailyAvailable {
+		// The rich projection can be readable before the daily monitor has
+		// completed its first poll. This is a healthy pending join, not a
+		// malformed rich projection or a generation mismatch.
+		metrics.SetCriticalMessageProjectionState(source, "rich", false, 1)
+		metrics.HLCriticalMessageGenerationMatch.WithLabelValues(source).Set(0)
+		metrics.MarkSourceReadOutcome(metrics.SourceCriticalLocations, true)
+		metrics.MarkSourcePublication(metrics.SourceCriticalLocations)
+		metrics.MarkMonitorPublication("crit_locations")
+		return nil
+	}
 	if !matched {
 		metrics.SetCriticalMessageProjectionState(source, "rich", false, 1)
 		metrics.HLCriticalMessageGenerationMatch.WithLabelValues(source).Set(0)

--- a/internal/monitors/crit_msg_monitor_test.go
+++ b/internal/monitors/crit_msg_monitor_test.go
@@ -65,6 +65,72 @@ func critRichFixture(base time.Time, bugs, crits int64, locations string) string
 	return fmt.Sprintf(`{"start_time":%q,"n_bugs":%d,"n_crits":%d,"code_location_and_stats":%s}`, base.UTC().Format("2006-01-02T15:04:05.999999999"), bugs, crits, locations)
 }
 
+func TestCriticalRichProjectionWaitsForDailyGenerationWithoutSchemaError(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-time.Hour)
+	path := filepath.Join(t.TempDir(), "hl-visor.json")
+	locations := `[[{"fln":"/build/src/startup.rs","line":7},{"n":3,"is_ignored":false,"first_seen":"2026-08-08T00:00:00","last_seen":"2026-08-08T00:01:00"}]]`
+	if err := os.WriteFile(path, []byte(critRichFixture(base, 1, 2, locations)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	store := newCritGenerationStore()
+	state := &critLocationsState{store: store, active: make(map[[2]string]struct{})}
+	labels := map[string]string{"file": "startup.rs", "line": "7"}
+	metrics.HLNodeCritLocation.DeleteLabelValues("startup.rs", "7")
+	metrics.HLNodeCritLocationIgnored.DeleteLabelValues("startup.rs", "7")
+	metrics.HLNodeCritLocationLastSeenSeconds.DeleteLabelValues("startup.rs", "7")
+	defer func() {
+		metrics.HLNodeCritLocation.DeleteLabelValues("startup.rs", "7")
+		metrics.HLNodeCritLocationIgnored.DeleteLabelValues("startup.rs", "7")
+		metrics.HLNodeCritLocationLastSeenSeconds.DeleteLabelValues("startup.rs", "7")
+	}()
+	schemaErrors := metrics.HLExporterSourceErrorsTotal.WithLabelValues("critical_locations", "schema")
+	errorsBefore := hostMetricValue(t, schemaErrors)
+	if err := tickCritLocationsAt(path, state, now.Add(time.Second)); err != nil {
+		t.Fatalf("valid rich projection before daily startup: %v", err)
+	}
+	if got := hostMetricValue(t, schemaErrors); got != errorsBefore {
+		t.Fatalf("pending daily generation incremented schema errors: before=%v after=%v", errorsBefore, got)
+	}
+	if value, ok := b03CollectorValue(t, metrics.HLCriticalMessageProjectionAvailable, map[string]string{"source": "hl-visor", "projection": "rich"}); !ok || value != 0 {
+		t.Fatalf("pending rich availability = %v, %v", value, ok)
+	}
+	if value, ok := b03CollectorValue(t, metrics.HLCriticalMessageProjectionParseOK, map[string]string{"source": "hl-visor", "projection": "rich"}); !ok || value != 1 {
+		t.Fatalf("pending rich parse state = %v, %v", value, ok)
+	}
+	if value, ok := b03CollectorValue(t, metrics.HLCriticalMessageGenerationMatch, map[string]string{"source": "hl-visor"}); !ok || value != 0 {
+		t.Fatalf("pending generation match = %v, %v", value, ok)
+	}
+	if b03CollectorHasLabels(t, metrics.HLNodeCritLocation, labels) {
+		t.Fatal("pending rich projection published an unmatched location")
+	}
+
+	store.set("hl-visor", critDailyProjection{
+		available: true,
+		generation: critGeneration{
+			Source:     "hl-visor",
+			SampleTime: now,
+			BaseTime:   base,
+			NBugs:      1,
+			NCrits:     2,
+			NLocations: 1,
+		},
+	})
+	if err := tickCritLocationsAt(path, state, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("matching daily generation did not recover: %v", err)
+	}
+	if value, ok := b03CollectorValue(t, metrics.HLNodeCritLocation, labels); !ok || value != 3 {
+		t.Fatalf("recovered rich location = %v, %v", value, ok)
+	}
+	if value, ok := b03CollectorValue(t, metrics.HLCriticalMessageGenerationMatch, map[string]string{"source": "hl-visor"}); !ok || value != 1 {
+		t.Fatalf("recovered generation match = %v, %v", value, ok)
+	}
+}
+
 func TestCriticalVisorGenerationMatchingRollbackAndEmptyClear(t *testing.T) {
 	root := t.TempDir()
 	now := time.Now().UTC().Truncate(time.Second)

--- a/internal/monitors/critical_generation.go
+++ b/internal/monitors/critical_generation.go
@@ -65,15 +65,20 @@ func (s *critGenerationStore) get(source string) (critDailyProjection, bool) {
 
 // withAvailable serializes a rich-projection match and commit against daily
 // generation replacement/withdrawal. The callback runs only while the exact
-// daily generation remains available.
-func (s *critGenerationStore) withAvailable(source string, fn func(critGeneration) bool) (critGeneration, bool) {
+// daily generation remains available. available distinguishes a daily
+// projection that has not arrived yet from a present projection that failed
+// the generation match.
+func (s *critGenerationStore) withAvailable(source string, fn func(critGeneration) bool) (generation critGeneration, available, matched bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	projection, ok := s.sources[source]
-	if !ok || !projection.available || !fn(projection.generation) {
-		return critGeneration{}, false
+	if !ok || !projection.available {
+		return critGeneration{}, false, false
 	}
-	return projection.generation, true
+	if !fn(projection.generation) {
+		return projection.generation, true, false
+	}
+	return projection.generation, true, true
 }
 
 var sharedCritGenerations = newCritGenerationStore()


### PR DESCRIPTION
Small startup fix for critical-message projections while loading. No metric or config changes.

Checks:
- full Go and race test suites
- vet, Staticcheck, govulncheck, generated-file check
- Linux amd64 and arm64 builds
- Prometheus alert rules and fixtures