### PR TITLE
Accept current no-quorum gossip close shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.0.6] - 2026-08-09
+
+### Fixed
+
+- Accept an alternate no-quorum gossip-close payload format alongside the existing structure.
+
 ## [v4.0.5] - 2026-08-09
 
 ### Fixed

--- a/internal/monitors/gossip_connections_monitor.go
+++ b/internal/monitors/gossip_connections_monitor.go
@@ -203,8 +203,12 @@ func validKnownGossipPayload(tag string, inner []json.RawMessage) bool {
 		}
 		var endpoint, stream string
 		return unmarshalRequiredJSON(inner[1], &endpoint) == nil && unmarshalRequiredJSON(inner[2], &stream) == nil
-	case "closing gossip stream because no quorum yet", "finished checks", "sending abci_state",
-		"successfully sent abci_state":
+	case "closing gossip stream because no quorum yet":
+		// The post-2026-08-09 testnet build emits a nonempty string plus an
+		// array, while retained generations use the IP-object/bool form. The
+		// payload is validation-only and never becomes metric identity.
+		return validGossipIPFlagPayload(inner, false) || validGossipStringArrayPayload(inner)
+	case "finished checks", "sending abci_state", "successfully sent abci_state":
 		return validGossipIPFlagPayload(inner, false)
 	case "dropping connection after sending abci state":
 		// Current mainnet can use a short string in the third field while
@@ -272,6 +276,14 @@ func validGossipIPBoolOrStringPayload(inner []json.RawMessage) bool {
 	}
 	var detail string
 	return unmarshalRequiredJSON(inner[2], &detail) == nil && strings.TrimSpace(detail) != ""
+}
+
+func validGossipStringArrayPayload(inner []json.RawMessage) bool {
+	if len(inner) != 3 || !rawJSONArray(inner[2]) {
+		return false
+	}
+	var detail string
+	return unmarshalRequiredJSON(inner[1], &detail) == nil && strings.TrimSpace(detail) != ""
 }
 
 func rawExactIPObject(raw json.RawMessage) bool {

--- a/internal/monitors/gossip_connections_monitor_test.go
+++ b/internal/monitors/gossip_connections_monitor_test.go
@@ -41,6 +41,11 @@ func TestParseGossipConnectionLine_KnownEvents(t *testing.T) {
 			"got_tcp_greeting",
 		},
 		{
+			"no quorum current testnet string array",
+			`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet","waiting",[]]]`,
+			"closing_gossip_stream_no_quorum_yet",
+		},
+		{
 			"sending evm kvs current mainnet object-only",
 			`["2026-08-09T03:00:03",["sending evm kvs",{"Ip":"203.0.113.3"}]]`,
 			"sending_evm_kvs",
@@ -204,6 +209,11 @@ func TestParseGossipConnectionLine_ExactMatchingAndPayloadShape(t *testing.T) {
 	}
 	for _, line := range []string{
 		`["2026-08-08T03:00:03",["finished checks",{"Ip":"192.0.2.1"}]]`,
+		`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet","",[]]]`,
+		`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet","  ",[]]]`,
+		`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet",null,[]]]`,
+		`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet","waiting",{}]]`,
+		`["2026-08-09T08:18:55",["closing gossip stream because no quorum yet","waiting",null]]`,
 		`["2026-08-09T03:00:03",["sending evm kvs",{}]]`,
 		`["2026-08-09T03:00:03",["marking node_ip as verified",{"Ip":"192.0.2.1","extra":true}]]`,
 		`["2026-08-09T03:00:03",["closing gossip stream because peer is already connected",{"Ip":"192.0.2.1","extra":true}]]`,


### PR DESCRIPTION
Adds support for a second no-quorum gossip-close payload shape emitted by a recent node build. Existing metrics, labels, configurations, dashboards, and alerts remain unchanged.